### PR TITLE
Install requirements for SSL SNI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ Flask==0.10.1
 gunicorn==18.0
 logstash_formatter==0.5.7
 requests==2.3.0
+ndg-httpsclient==0.3.2
+pyOpenSSL==0.14
+pyasn1==0.1.7


### PR DESCRIPTION
We use SNI to serve up *.<env>.performance.service.gov.uk in production,
sadly python2 does not support SNI out of the box which causes our
status check on stagecraft to fail.

There is information about it in:
- http://docs.python-requests.org/en/latest/community/faq/
- https://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484
- https://github.com/kennethreitz/requests/issues/749#issuecomment-19187417

These point to using this combination of libraries to replace the
default SSL handling in python2.
