### PR TITLE
Add Sign-on-o-tron flow

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -1,0 +1,17 @@
+from flask import Flask
+from os import getenv
+
+app = Flask(__name__)
+
+GOVUK_ENV = getenv('GOVUK_ENV', 'development')
+
+app.config.from_object('admin.config.{0}'.format(GOVUK_ENV))
+app.secret_key = app.config['COOKIE_SECRET_KEY']
+
+import admin.main
+import admin.authentication
+
+
+def start(port):
+    app.debug = True
+    app.run('0.0.0.0', port=port)

--- a/admin/authentication.py
+++ b/admin/authentication.py
@@ -1,0 +1,28 @@
+from admin import app
+from flask import redirect, request, session
+from requests_oauthlib import OAuth2Session
+
+
+@app.route("/login", methods=['GET'])
+def login():
+    gds_session = OAuth2Session(app.config['SIGNON_OAUTH_ID'],
+                                redirect_uri='{0}/auth/gds/callback'.format(
+                                    app.config['ADMIN_HOST']))
+    authorization_url, state = gds_session.authorization_url(
+        '{0}/oauth/authorize'.format(app.config['SIGNON_BASE_URL']))
+    session['oauth_state'] = state
+    return redirect(authorization_url)
+
+
+@app.route("/auth/gds/callback", methods=['GET'])
+def authorize():
+    gds_session = OAuth2Session(app.config['SIGNON_OAUTH_ID'],
+                                state=session['oauth_state'],
+                                redirect_uri='{0}/auth/gds/callback'.format(
+                                    app.config['ADMIN_HOST']))
+    token = gds_session.fetch_token('{0}/oauth/token'.format(
+        app.config['SIGNON_BASE_URL']),
+        client_secret=app.config['SIGNON_OAUTH_SECRET'],
+        authorization_response=request.url)
+    return jsonify(gds_session.get('{0}/user.json'.format(
+        app.config['SIGNON_BASE_URL'])).json())

--- a/admin/config/development.py
+++ b/admin/config/development.py
@@ -1,2 +1,10 @@
+COOKIE_SECRET_KEY = 'placeholder_cookie_secret_key'
+
+ADMIN_HOST = 'http://admin.development.performance.service.gov.uk'
+
 BACKDROP_HOST = 'http://www.development.performance.service.gov.uk'
 STAGECRAFT_HOST = 'http://stagecraft.development.performance.service.gov.uk'
+
+SIGNON_OAUTH_ID = 'oauth_id'
+SIGNON_OAUTH_SECRET = 'oauth_secret'
+SIGNON_BASE_URL = 'https://signon.dev.gov.uk'

--- a/admin/main.py
+++ b/admin/main.py
@@ -1,13 +1,6 @@
-from flask import Flask, jsonify
-from os import getenv
+from admin import app
+from flask import jsonify
 import requests
-
-
-GOVUK_ENV = getenv('GOVUK_ENV', 'development')
-
-app = Flask(__name__)
-
-app.config.from_object('admin.config.{0}'.format(GOVUK_ENV))
 
 
 @app.route("/", methods=['GET'])
@@ -41,8 +34,3 @@ def status():
         app_status['stagecraft'] = error_status
 
     return jsonify(app_status)
-
-
-def start(port):
-    app.debug = True
-    app.run('0.0.0.0', port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask==0.10.1
 gunicorn==18.0
 logstash_formatter==0.5.7
 requests==2.3.0
+requests-oauthlib==0.4.1
 ndg-httpsclient==0.3.2
 pyOpenSSL==0.14
 pyasn1==0.1.7

--- a/start.py
+++ b/start.py
@@ -1,11 +1,11 @@
 from argh import arg
 from argh.dispatching import dispatch_command
-from admin import app as app
+import admin
 
 
 @arg('port', type=int, help='The port number to run the app on')
 def start_app(port):
-    app.start(port)
+    admin.start(port)
 
 
 if __name__ == '__main__':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ def performance_platform_status_mock(url, request):
 
 class AppTestCase(unittest.TestCase):
     def setUp(self):
-        self.app = app.app.test_client()
+        self.app = app.test_client()
 
     def test_status_endpoint_returns_ok(self):
         response = self.app.get("/_status")


### PR DESCRIPTION
This commit:
- Adds a `/login` endpoint that redirects to our signon provider
- Adds a callback endpoint to receive the user from the provider
- Reorganises the app slightly to pull the authentication stuff out into a separate file
