### PR TITLE
Fix redis sessions

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -19,6 +19,13 @@ import admin.authentication
 from redis import Redis
 from admin.redis_session import RedisSessionInterface
 
+app.redis_instance = Redis(
+    host=app.config['REDIS_HOST'],
+    port=app.config['REDIS_PORT']
+)
+app.session_interface = RedisSessionInterface(
+    redis=app.redis_instance, prefix='admin_app:session:')
+
 
 def start(port):
     app.debug = app.config['DEBUG'] or False
@@ -29,10 +36,4 @@ def start(port):
              asset_dir='admin/assets/scss/manifest',
              load_paths=[
                  path.join(path.dirname(__file__), 'assets/scss')])
-    app.redis_instance = Redis(
-        host=app.config['REDIS_HOST'],
-        port=app.config['REDIS_PORT']
-    )
-    app.session_interface = RedisSessionInterface(
-        redis=app.redis_instance, prefix='admin_app:session:')
     app.run('0.0.0.0', port=port)


### PR DESCRIPTION
Gunicorn does not call the `start` method, so the session config is not
picked up. We may want to change the convention and have an entry point
that is shared between development and production modes of running the
app, but this change should quickly fix the redis sessions that are
causing issues
