### PR TITLE
Add signed in decorator to simplify mocking

### DIFF
--- a/tests/admin/support/flask_app_test_case.py
+++ b/tests/admin/support/flask_app_test_case.py
@@ -1,7 +1,23 @@
 from flask.ext.testing import TestCase
 from hamcrest import assert_that, equal_to
+from functools import wraps
 
 from admin import app
+
+
+def signed_in(f):
+    @wraps(f)
+    def set_session_signed_in(*args, **kwargs):
+        self = args[0]
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess.update({
+                    'oauth_token': {
+                        'access_token': 'token'},
+                    'oauth_user': 'a user'})
+            kwargs['client'] = client
+            return f(*args, **kwargs)
+    return set_session_signed_in
 
 
 class FlaskAppTestCase(TestCase):

--- a/tests/admin/test_upload.py
+++ b/tests/admin/test_upload.py
@@ -1,36 +1,33 @@
 from hamcrest import assert_that, equal_to, ends_with, contains_string
 from mock import patch, Mock
 from StringIO import StringIO
-from tests.admin.support.flask_app_test_case import FlaskAppTestCase
+from tests.admin.support.flask_app_test_case import FlaskAppTestCase, signed_in
 import requests
 
 
 class UploadTestCase(FlaskAppTestCase):
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     @patch('admin.files.uploaded.UploadedFile.is_virus')
     @patch('performanceplatform.client.data_set.DataSet.post')
     def test_user_can_post_to_upload_data(
             self,
             data_set_post_patch,
             is_virus_patch,
-            get_admin_client_patch,
-            signed_in_patch):
+            get_data_set_patch,
+            client):
         is_virus_patch.return_value = False
-        signed_in_patch.return_value = True
-        client_mock = Mock()
-        client_mock.get_data_set.return_value = {
+        get_data_set_patch.return_value = {
             'bearer_token': 'abc123', 'foo': 'bar'
         }
-        get_admin_client_patch.return_value = client_mock
 
         post_data = {
             'carers-allowance-volumetrics-file':
                 (StringIO('_timestamp,foo\n2014-08-05T00:00:00Z,40'),
                     'MYSPECIALFILE.csv')
         }
-        response = self.client.post(
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data=post_data)
 
@@ -45,26 +42,22 @@ class UploadTestCase(FlaskAppTestCase):
             'upload_okay_message',
             {u'data_type': u'volumetrics', u'data_group': u'carers-allowance'})
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     @patch('performanceplatform.client.data_set.DataSet.post')
     def test_ask_for_file_if_none_chosen(
             self,
             data_set_post_patch,
-            get_admin_client_patch,
-            signed_in_patch):
-        signed_in_patch.return_value = True
-        client_mock = Mock()
-        client_mock.get_data_set.return_value = {
+            get_data_set_patch,
+            client):
+        get_data_set_patch.return_value = {
             'bearer_token': 'abc123', 'foo': 'bar'
         }
-        client_mock.list_data_sets.return_value = [{}]
-        get_admin_client_patch.return_value = client_mock
 
         post_data = {
             'carers-allowance-volumetrics-file': (None, "")
         }
-        response = self.client.post(
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data=post_data)
 
@@ -72,17 +65,14 @@ class UploadTestCase(FlaskAppTestCase):
         assert_that(response.headers['Location'], ends_with('/upload-data'))
         assert_that(response.status_code, equal_to(302))
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     def test_no_data_set_config_returns_error(
             self,
-            get_admin_client_patch,
-            signed_in_patch):
-        signed_in_patch.return_value = True
-        client_mock = Mock()
-        client_mock.get_data_set.return_value = None
-        get_admin_client_patch.return_value = client_mock
-        response = self.client.post(
+            get_data_set_patch,
+            client):
+        get_data_set_patch.return_value = None
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data={'file': (StringIO('data'), 'file.xlsx')})
 
@@ -90,22 +80,19 @@ class UploadTestCase(FlaskAppTestCase):
             'There is no data set of for data-group'))
         assert_that(response.status_code, equal_to(404))
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     def test_http_error_from_stagecraft_flashes_message(
             self,
-            get_admin_client_patch,
-            signed_in_patch):
-        signed_in_patch.return_value = True
+            get_data_set_patch,
+            client):
         bad_response = requests.Response()
         bad_response.status_code = 403
         bad_response.json = Mock(return_value={})
         http_error = requests.HTTPError()
         http_error.response = bad_response
-        client_mock = Mock()
-        client_mock.get_data_set.side_effect = http_error
-        get_admin_client_patch.return_value = client_mock
-        response = self.client.post(
+        get_data_set_patch.side_effect = http_error
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data={'file': (StringIO('data'), 'file.xlsx')})
 
@@ -115,24 +102,21 @@ class UploadTestCase(FlaskAppTestCase):
         assert_that(response.headers['Location'], ends_with('/upload-data'))
         assert_that(response.status_code, equal_to(302))
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     @patch('admin.files.uploaded.UploadedFile.is_virus')
     @patch('performanceplatform.client.data_set.DataSet.post')
     def test_http_error_from_backdrop_flashes_message(
             self,
             data_set_post_patch,
             is_virus_patch,
-            get_admin_client_patch,
-            signed_in_patch):
+            get_data_set_patch,
+            client):
         is_virus_patch.return_value = False
-        client_mock = Mock()
-        client_mock.get_data_set.return_value = {
+        get_data_set_patch.return_value = {
             'bearer_token': 'abc123', 'foo': 'bar'
         }
-        get_admin_client_patch.return_value = client_mock
 
-        signed_in_patch.return_value = True
         bad_response = requests.Response()
         bad_response.status_code = 401
         bad_response.json = Mock(return_value={})
@@ -144,7 +128,7 @@ class UploadTestCase(FlaskAppTestCase):
                 (StringIO('_timestamp,foo\n2014-08-05T00:00:00Z,40'),
                     'MYSPECIALFILE.csv')
         }
-        response = self.client.post(
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data=post_data)
 
@@ -153,30 +137,27 @@ class UploadTestCase(FlaskAppTestCase):
         assert_that(response.headers['Location'], ends_with('/upload-data'))
         assert_that(response.status_code, equal_to(302))
 
-    @patch('admin.helpers.signed_in')
-    @patch('admin.helpers.get_admin_client')
+    @signed_in
+    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
     @patch('admin.files.uploaded.UploadedFile.validate')
     @patch('performanceplatform.client.data_set.DataSet.post')
     def test_redirect_to_error_if_problems_and_prevent_post(
             self,
             data_set_post_patch,
             validate_patch,
-            get_admin_client_patch,
-            signed_in_patch):
+            get_data_set_patch,
+            client):
         validate_patch.return_value = ["99"]
-        client_mock = Mock()
-        client_mock.get_data_set.return_value = {
+        get_data_set_patch.return_value = {
             'bearer_token': 'abc123', 'foo': 'bar'
         }
-        get_admin_client_patch.return_value = client_mock
 
-        signed_in_patch.return_value = True
         post_data = {
             'carers-allowance-volumetrics-file':
                 (StringIO('_timestamp,foo\n2014-08-05T00:00:00Z,40'),
                     'MYSPECIALFILE.csv')
         }
-        response = self.client.post(
+        response = client.post(
             '/upload-data/carers-allowance/volumetrics',
             data=post_data)
 
@@ -185,23 +166,19 @@ class UploadTestCase(FlaskAppTestCase):
         assert_that(response.status_code, equal_to(302))
         assert_that(data_set_post_patch.called, equal_to(False))
 
+    @signed_in
     @patch('performanceplatform.client.admin.AdminAPI.list_data_sets')
     def test_data_sets_redirects_to_sign_out_when_403_on_data_set_list(
             self,
-            mock_data_set_list):
+            mock_data_set_list,
+            client):
         bad_response = requests.Response()
         bad_response.status_code = 403
         http_error = requests.exceptions.HTTPError()
         http_error.response = bad_response
         mock_data_set_list.side_effect = http_error
-        with self.client as client:
-            with client.session_transaction() as sess:
-                sess.update({
-                    'oauth_token': {
-                        'access_token': 'token'},
-                    'oauth_user': 'a user'})
-            response = client.get("/upload-data")
-            assert_that(response.status_code, equal_to(302))
-            assert_that(
-                response.headers['Location'],
-                ends_with('/sign-out'))
+        response = client.get("/upload-data")
+        assert_that(response.status_code, equal_to(302))
+        assert_that(
+            response.headers['Location'],
+            ends_with('/sign-out'))


### PR DESCRIPTION
We can now patch methods on the AdminApi directly as we have a real
session for a user
