### PR TITLE
Simplify the status endpoint and return status

### DIFF
--- a/tests/admin/test_main.py
+++ b/tests/admin/test_main.py
@@ -29,8 +29,8 @@ class AppTestCase(FlaskAppTestCase):
         with HTTMock(performance_platform_status_mock):
             response = self.app.get("/_status")
         assert_that(response.status_code, equal_to(200))
-        assert_that(json.loads(response.data)['admin'],
-                    equal_to({"status": "ok"}))
+        assert_that(json.loads(response.data)['status'],
+                    equal_to('ok'))
 
     def test_status_endpoint_returns_dependent_app_status(self):
         with HTTMock(performance_platform_status_mock):


### PR DESCRIPTION
If one of our deps isn't ok then we should be sending a 5xx status.

There was a lot of dupe between the two status checks so I've pulled it
out into a function.

The status of the admin app is now dependant on the status of its
dependencies.
