### PR TITLE
Fix bug when parsing rows containing just numbers

### DIFF
--- a/admin/files/parsers/util.py
+++ b/admin/files/parsers/util.py
@@ -2,7 +2,11 @@ from admin.files.parsers import ParseError
 
 
 def remove_blanks(rows):
-    return filter(lambda r: not all(v is None or len(v) == 0 for v in r), rows)
+    def blank_filter(r):
+        return not all(v is None or
+                       (isinstance(v, basestring) and len(v) == 0) for v in r)
+
+    return filter(blank_filter, rows)
 
 
 def make_dicts(rows):

--- a/tests/admin/files/parsers/test_util.py
+++ b/tests/admin/files/parsers/test_util.py
@@ -73,3 +73,17 @@ class TestMakeRecords(unittest.TestCase):
             {"name": "val1", "size": 123},
             {"name": "val2", "size": 456},
         ))
+
+    def test_processes_rows_containg_just_numbers_correctly(self):
+        rows = [
+            ['count'],
+            [818],
+            [602],
+        ]
+
+        records = list(make_dicts(rows))
+
+        assert_that(records, only_contains(
+            {'count': 818},
+            {'count': 602},
+        ))


### PR DESCRIPTION
If a row contains a single column with numbers, parsing will fail:

```
TypeError: object of type 'int' has no len()
```

Test for a string before calling `len()`.
