### PR TITLE
Wrap data type in span

### DIFF
--- a/admin/templates/upload/form.html
+++ b/admin/templates/upload/form.html
@@ -10,6 +10,6 @@
     <button class="btn btn-primary btn-xs" type="submit">Upload</button>
   </div>
   <div class="dz-message">
-    Drop or select a spreadsheet to upload to {{ data_set.data_type }}
+    Drop or select a spreadsheet to upload to <span class="data-set-type">{{ data_set.data_type }}</span>
   </div>
 </form>


### PR DESCRIPTION
We need to be able to pick up which data types are listed in our smoke
tests. When the JS spins up it removes the fallback div so we cannot
pull it from there.
