### PR TITLE
Remove redundant dataset permission

### DIFF
--- a/admin/config/development.py
+++ b/admin/config/development.py
@@ -18,7 +18,6 @@ FAKE_OAUTH_USER = {
     "organisation_slug": "cabinet-office",
     "permissions": [
         "signin",
-        "dataset",
         "user",
         "admin",
     ],


### PR DESCRIPTION
It is not used in admin app, backdrop admin or stagecraft.
