### PR TITLE
Update published state when editing dashboard

### DIFF
--- a/admin/dashboards.py
+++ b/admin/dashboards.py
@@ -174,9 +174,8 @@ def build_dict_for_post(form):
             'query_parameters': json.loads(module.query_parameters.data),
             'order': index,
         })
-
     return {
-        'published': False,
+        'published': form.published.data,
         'page-type': 'dashboard',
         'dashboard-type': form.dashboard_type.data,
         'slug': form.slug.data,

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -97,3 +97,4 @@ class DashboardCreationForm(Form):
     transaction_link = TextField('Transaction link')
 
     modules = FieldList(FormField(ModuleForm), min_entries=0)
+    published = HiddenField('published', default=False)

--- a/admin/templates/dashboards/create.html
+++ b/admin/templates/dashboards/create.html
@@ -11,6 +11,7 @@
   <form method="post" action="{{ url_for('dashboard_admin_create_post') }}" role="form" class="form-horizontal">
 {% endif %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    {{ form.published() }}
 
     <div class="well">
 

--- a/tests/admin/test_forms.py
+++ b/tests/admin/test_forms.py
@@ -38,3 +38,5 @@ class DashboardTestCase(TestCase):
             equal_to(dashboard_dict['modules'][0]['description']))
         assert_that(
             dict_for_post['links'], equal_to(dashboard_dict['links']))
+        assert_that(
+            dict_for_post['published'], equal_to(dashboard_dict['published']))


### PR DESCRIPTION
This is a non user editable field (unless they edit the form field in
Firebug). It defaults to False for new dashboards, and will pull the
correct value from dashboards when editing them.

If we wanted something more secure, we may be able to store the published state
in the session, or do another dashboard lookup on stagecraft when submitting 
the form to make sure it is consistent, but the hidden form field seems easier
without too many drawbacks while the app is internal only.
