### PR TITLE
Pass client_id through to user.json

### DIFF
--- a/admin/authentication.py
+++ b/admin/authentication.py
@@ -41,8 +41,9 @@ def authorize():
         client_secret=app.config['SIGNON_OAUTH_SECRET'],
         authorization_response=request.url)
     # need to pass ?client_id=[SIGNON_OAUTH_ID]
-    user = gds_session.get('{0}/user.json'.format(
-        app.config['SIGNON_BASE_URL'])).json()
+    user = gds_session.get('{0}/user.json?client_id={1}'.format(
+        app.config['SIGNON_BASE_URL'],
+        app.config['SIGNON_OAUTH_ID'])).json()
     if 'signin' in user['user']['permissions']:
         flash("You have been successfully signed in")
     session['oauth_user'] = user['user']

--- a/tests/admin/test_authentication.py
+++ b/tests/admin/test_authentication.py
@@ -73,6 +73,30 @@ class AuthenticationTestCase(FlaskAppTestCase):
         assert_equal(response.headers['Location'], 'http://localhost/')
         assert_equal(response.status_code, 302)
 
+    def test_authorize_sends_client_id_with_user_json(
+            self,
+            oauth_authorization_url_patch,
+            oauth_get_patch,
+            oauth_fetch_token_patch):
+        token = "token_token"
+        user = {
+            'permissions': ['signin'],
+            'uid': "bleep_bloop_blarp"
+        }
+        oauth_get_response = Mock()
+        oauth_get_response.json = Mock(return_value={
+            'user': user
+        })
+        oauth_get_patch.return_value = oauth_get_response
+        oauth_fetch_token_patch.return_value = token
+        with self.client.session_transaction() as sess:
+            sess['oauth_state'] = "foo"
+        response = self.client.get(
+            '/auth/gds/callback')
+
+        oauth_get_patch.assert_called_with(
+            'http://signon.dev.gov.uk/user.json?client_id=oauth_id')
+
     def test_authorize_does_not_sign_in_if_user_cannot_sign_in(
             self,
             oauth_authorization_url_patch,


### PR DESCRIPTION
Signonotron2 requires you to pass the client_id through to the user.json
endpoint so that you can't use any apps token to gain access.
