### PR TITLE
Enable recording of notes about a dashboard

### DIFF
--- a/admin/dashboards.py
+++ b/admin/dashboards.py
@@ -199,6 +199,8 @@ def build_dict_for_post(form):
         'customer_type': form.customer_type.data,
         'business_model': form.business_model.data,
         'strapline': form.strapline.data,
+        'costs': form.costs.data,
+        'other_notes': form.other_notes.data,
         'links': [{
             'title': form.transaction_title.data,
             'url': form.transaction_link.data,

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -120,6 +120,8 @@ class DashboardCreationForm(Form):
         ('Taxpayers', 'Taxpayers'),
         ('Fees and charges, and taxpayers', 'Fees and charges, and taxpayers'),
     ])
+    costs = TextAreaField('Notes on costs')
+    other_notes = TextAreaField('Other notes')
 
     transaction_title = TextField('Transaction action')
     transaction_link = TextField('Transaction link')

--- a/admin/templates/dashboards/create.html
+++ b/admin/templates/dashboards/create.html
@@ -97,6 +97,28 @@
           </p>
         </div>
       </div>
+
+      <div class="form-group">
+        {{ form.costs.label(class='col-sm-2 control-label') }}
+        <div class="col-sm-10">
+          {{ form.costs(class='form-control') }}
+          <p class="help-block">
+            Notes on how costs are made up.
+            These are shown at the bottom of the dashboard.
+          </p>
+        </div>
+      </div>
+
+      <div class="form-group">
+        {{ form.other_notes.label(class='col-sm-2 control-label') }}
+        <div class="col-sm-10">
+          {{ form.other_notes(class='form-control') }}
+          <p class="help-block">
+            Other notes to help people interpret the dashboard.
+            These are shown at the bottom of the dashboard.
+          </p>
+        </div>
+      </div>
     </div>
 
     <div class="well">


### PR DESCRIPTION
Added the Dashboard#costs and Dashboard#other_notes fields to the dashboard form in support of https://www.agileplannerapp.com/boards/15088/cards/8014.
