### PR TITLE
Add the dashboard title near the submit button

### DIFF
--- a/admin/templates/dashboards/create.html
+++ b/admin/templates/dashboards/create.html
@@ -251,7 +251,13 @@
       {% else %}
         <input type="submit" class="pull-left btn btn-success" value="Create dashboard" name="create">
       {% endif %}
-      <p class="pull-left add-left-margin control-label">You are in <strong>{{environment.human_name}}</strong></p>
+      <p class="pull-left add-left-margin control-label">
+        You're
+        {% if form.title.data %}
+        editing the <strong>{{ form.title.data }}</strong> dashboard
+        {% endif %}
+        in <strong>{{environment.human_name.lower()}}</strong>
+      </p>
     </div>
 
 </form>


### PR DESCRIPTION
Dashboard editors want to be able to see the name of the dashboard that they're editing near the submit button, to act as a check that they're doing the right thing.

This is helpful if you have a lot of tabs open, for example.
