### PR TITLE
Add a link to preview the dashboard

### DIFF
--- a/admin/config/development.py
+++ b/admin/config/development.py
@@ -5,6 +5,7 @@ ADMIN_HOST = 'https://admin-beta.development.performance.service.gov.uk'
 BACKDROP_HOST = 'http://www.development.performance.service.gov.uk'
 STAGECRAFT_HOST = 'http://stagecraft.development.performance.service.gov.uk'
 
+GOVUK_SITE_URL = 'http://spotlight.development.performance.service.gov.uk'
 SIGNON_OAUTH_ID = 'oauth_id'
 SIGNON_OAUTH_SECRET = 'oauth_secret'
 SIGNON_BASE_URL = 'http://signon.dev.gov.uk'

--- a/admin/dashboards.py
+++ b/admin/dashboards.py
@@ -11,6 +11,7 @@ from flask import (
 )
 from admin.forms import convert_to_dashboard_form
 
+import cgi
 import json
 import requests
 import functools
@@ -130,7 +131,12 @@ def dashboard_update(admin_client, form, uuid):
             raise InvalidFormFieldError()
         dict_for_post = build_dict_for_post(form)
         admin_client.update_dashboard(uuid, dict_for_post)
-        flash('Updated the {} dashboard'.format(form.slug.data), 'success')
+        flash('Updated the <a href="{0}/performance/{1}">{2}</a> dashboard'
+              .format(
+                  app.config['GOVUK_SITE_URL'],
+                  form.slug.data,
+                  cgi.escape(form.title.data)
+              ), 'success')
         del session['pending_dashboard']
         return redirect(url_for('dashboard_admin_index'))
     except (requests.HTTPError, ValueError, InvalidFormFieldError) as e:


### PR DESCRIPTION
After editing the dashboard, it is incredibly common for people to want to view their changes. We should not make them have to copy and paste a slug to do that.
