### PR TITLE
Improve JSON editing

### DIFF
--- a/admin/assets/scss/performanceplatform-admin/style.scss
+++ b/admin/assets/scss/performanceplatform-admin/style.scss
@@ -25,3 +25,7 @@
   margin-top: 3em;
   padding: 1em 0 2em;
 }
+
+textarea.json-field {
+  height: 10em;
+}

--- a/admin/fields/json_textarea.py
+++ b/admin/fields/json_textarea.py
@@ -1,0 +1,37 @@
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+
+from wtforms import StringField
+from wtforms.compat import text_type
+from wtforms.widgets import html_params, HTMLString
+
+import json
+
+
+class JSONTextArea(object):
+    """
+    Renders a textarea element which contains JSON data that has been
+    pretty-printed.
+    """
+    def __call__(self, field, **kwargs):
+        kwargs.setdefault('id', field.id)
+        field_as_string = text_type(field._value())
+        try:
+            pretty_printed_string = json.dumps(
+                json.loads(field_as_string), indent=4, sort_keys=True)
+        except ValueError:
+            pretty_printed_string = field_as_string
+        return HTMLString('<textarea %s>%s</textarea>' % (
+            html_params(name=field.name, **kwargs),
+            escape(pretty_printed_string, quote=False)
+        ))
+
+
+class JSONTextAreaField(StringField):
+    """
+    This field represents an HTML ``<textarea>`` which is used to pretty-print
+    JSON to make it easier to edit.
+    """
+    widget = JSONTextArea()

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -1,4 +1,5 @@
 from admin import app
+from admin.fields.json_textarea import JSONTextAreaField
 from wtforms import (FieldList, Form, FormField, TextAreaField, TextField,
                      SelectField, HiddenField, validators)
 from performanceplatform.client import AdminAPI
@@ -59,8 +60,8 @@ class ModuleForm(Form):
     description = TextField('Description')
     info = TextField('Info')
 
-    query_parameters = TextAreaField('Query parameters', default='{}')
-    options = TextAreaField('Visualisation settings', default='{}')
+    query_parameters = JSONTextAreaField('Query parameters', default='{}')
+    options = JSONTextAreaField('Visualisation settings', default='{}')
 
 
 def get_organisation_choices(admin_client):

--- a/admin/templates/dashboards/create.html
+++ b/admin/templates/dashboards/create.html
@@ -224,7 +224,7 @@
           <div class="form-group">
             {{ module.query_parameters.label(class='col-sm-2 control-label') }}
             <div class="col-sm-10">
-              {{ module.query_parameters(class='form-control') }}
+              {{ module.query_parameters(class='form-control json-field') }}
               <p class="help-block">Query parameters must be <a href="http://jsonlint.com/" target="_blank">valid JSON</a></p>
             </div>
           </div>
@@ -232,7 +232,7 @@
           <div class="form-group">
             {{ module.options.label(class='col-sm-2 control-label') }}
             <div class="col-sm-10">
-              {{ module.options(class='form-control') }}
+              {{ module.options(class='form-control json-field') }}
               <p class="help-block">Adjust how the visualisation looks. Settings must be <a href="http://jsonlint.com/" target="_blank">valid JSON</a></p>
             </div>
           </div>


### PR DESCRIPTION
When editing JSON in the admin app, it gets difficult to read a large chunk of it.

This commit pretty-prints JSON by adding a new WTForms field type that reads the JSON string in using `json.loads()` and then calls `json.dumps()` with the indent and sort_keys options.

We should think about whether it would be useful to commit this upstream.