### PR TITLE
Add endpoint to view transform data

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -34,6 +34,7 @@ log_handler.set_up_logging(app, GOVUK_ENV)
 import admin.main
 import admin.authentication
 import admin.dashboards
+import admin.transforms
 import admin.upload
 
 

--- a/admin/templates/navbar/nav.html
+++ b/admin/templates/navbar/nav.html
@@ -30,7 +30,10 @@
           </li>
           {% if can_edit_dashboards(user) %}
             <li>
-              <a href="{{ url_for('dashboard_admin_index') }}">Administer dashboards</a>
+              <a href="{{ url_for('dashboard_admin_index') }}">Dashboards</a>
+            </li>
+            <li>
+              <a href="{{ url_for('transforms_index') }}">Transforms</a>
             </li>
           {% endif %}
           <li >

--- a/admin/templates/transforms/index.html
+++ b/admin/templates/transforms/index.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h2>Transforms</h2>
+
+<p>
+  <a href="{{ url_for('transforms_dotfile') }}">Download transform DOT file</a>.
+  You can use software like <a href="http://www.graphviz.org/">Graphviz</a> to render DOT files,
+  with a command like <code>dot transforms.dot -Tpng -o transforms.png</code>.
+</p>
+
+{% endblock %}

--- a/admin/transforms.py
+++ b/admin/transforms.py
@@ -1,0 +1,104 @@
+import requests
+
+from admin import app
+from admin.helpers import requires_authentication, base_template_context
+from colour import Color
+from flask import make_response, render_template, session
+from graphviz import Digraph
+
+
+@app.route("/transforms", methods=['GET'])
+@requires_authentication
+def transforms_index(admin_client):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+
+    return render_template('transforms/index.html', **template_context)
+
+
+@app.route("/transforms/dotfile", methods=['GET'])
+@requires_authentication
+def transforms_dotfile(admin_client):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+
+    transforms_url = '{0}/transforms'.format(app.config['STAGECRAFT_HOST'])
+    transforms = requests.get(transforms_url).json()
+
+    dot = Digraph(
+        name='Performance Platform transforms',
+        format='svg',
+        graph_attr={'rankdir': 'LR'},
+        node_attr={'shape': 'box', 'fontname': 'Helvetica', 'fontsize': '24'},
+        edge_attr={'fontname': 'Helvetica', 'fontsize': '24'},
+    )
+
+    output_datasets = []
+    output_transforms = []
+    dataset_id = 0
+
+    def dictionary_is_subset(subset, superset):
+        """Return a boolean indicating whether one dictionary is a subset
+           of another."""
+        return all(item in superset.items() for item in subset.items())
+
+    def find_dataset(dataset, dataset_list):
+        return [d for d in dataset_list if dictionary_is_subset(dataset, d)]
+
+    for transform in transforms:
+        ids = {
+            'input': None,
+            'output': None,
+        }
+
+        for key in ['input', 'output']:
+            dataset = transform[key]
+
+            filtered_datasets = find_dataset(dataset, output_datasets)
+
+            if filtered_datasets:
+                ids[key] = filtered_datasets[0]['id']
+            else:
+                ids[key] = dataset_id
+                dataset_id += 1
+
+                output_datasets.append({
+                    'id': str(ids[key]),
+                    'data-group': dataset['data-group'],
+                    'data-type': dataset['data-type'],
+                    'colour': Color(pick_for=dataset['data-type']).hex,
+                })
+
+        transform_type = transform['type']['function'].split('.')[3]
+
+        output_transforms.append({
+            'input': str(ids['input']),
+            'output': str(ids['output']),
+            'label': transform_type,
+            'colour': Color(pick_for=transform_type).hex,
+        })
+
+    for node in output_datasets:
+        dot.node(
+            node['id'],
+            '{0} {1}'.format(node['data-group'], node['data-type']),
+            fontcolor=node['colour']
+        )
+
+    for edge in output_transforms:
+        dot.edge(
+            edge['input'],
+            edge['output'],
+            label=edge['label'],
+            fontcolor=edge['colour']
+        )
+
+    resp = make_response(dot.source)
+    resp.content_type = 'text/plain'
+    resp.headers['Content-Disposition'] = 'attachment; filename=transforms.dot'
+
+    return resp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 argh==0.25.0
 blinker==1.3
+colour==0.0.5
 Flask==0.10.1
 Flask-Scss==0.3
 Flask-WTF==0.10.1
+graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2


### PR DESCRIPTION
This commit adds an endpoint that allows authenticated users to download a DOT file of transforms.

I chose this approach because it doesn't rely on installing Graphviz on our production machines, but still provides us with the ability to process the DOT file locally.