### PR TITLE
Clone a dashboard

### DIFF
--- a/admin/assets/scss/performanceplatform-admin/style.scss
+++ b/admin/assets/scss/performanceplatform-admin/style.scss
@@ -10,6 +10,24 @@
   }
 }
 
+ul.links {
+  padding-left: 0;
+  display: inline;
+  list-style: none;
+  font-size: inherit;
+
+  li {
+    display: inline-block;
+    margin-left: 3px;
+    border-left: 1px solid $gray-light;
+    padding-left: 6px;
+
+    &:first-child {
+      border-left: none;
+    }
+  }
+}
+
 .module {
   border-bottom: 1px solid #333;
   margin: 2em 0;

--- a/admin/dashboards.py
+++ b/admin/dashboards.py
@@ -133,7 +133,6 @@ def dashboard_form(admin_client, uuid=None):
                                      request.form)
     else:
         dashboard_dict = admin_client.get_dashboard(uuid)
-        module_types = ModuleTypes()
         form = convert_to_dashboard_form(
             dashboard_dict, admin_client, module_types)
 
@@ -145,6 +144,24 @@ def dashboard_form(admin_client, uuid=None):
         if request.args.get('section'):
             form.modules[-1].category.data = 'container'
 
+    return render_template('dashboards/create.html',
+                           form=form,
+                           **template_context)
+
+
+@app.route('{0}/clone'.format(DASHBOARD_ROUTE), methods=['GET'])
+@requires_authentication
+@requires_permission('dashboard')
+def dashboard_clone(admin_client):
+    template_context = base_template_context()
+    template_context['user'] = session['oauth_user']
+    dashboard_dict = admin_client.get_dashboard(request.args.get('uuid'))
+    form = convert_to_dashboard_form(
+        dashboard_dict, admin_client, ModuleTypes())
+    form['title'].data = ''
+    form['slug'].data = ''
+    for m in form.modules:
+        m['id'].data = ''
     return render_template('dashboards/create.html',
                            form=form,
                            **template_context)

--- a/admin/templates/dashboards/create.html
+++ b/admin/templates/dashboards/create.html
@@ -147,10 +147,10 @@
       <h2>Modules</h2>
 
       {% for module in form.modules %}
-        {{ module.form['id'] }}
-        {{ module['category'] }}
-
         <fieldset class="module">
+          {{ module.form['id'] }}
+          {{ module['category'] }}
+
           <div class="form-group">
             <div class="col-sm-12">
               <div class="pull-right">

--- a/admin/templates/dashboards/index.html
+++ b/admin/templates/dashboards/index.html
@@ -11,7 +11,17 @@
 
   <ul>
     {% for dashboard in dashboards %}
-      <li><a href="{{ url_for('dashboard_form', uuid=dashboard.id) }}">{{ dashboard.title }}</a></li>
+      <li>
+        {{ dashboard.title }}
+        <ul class='links'>
+          <li>
+            <a class='inline' href="{{ url_for('dashboard_form', uuid=dashboard.id) }}">Edit</a>
+          </li>
+          <li>
+            <a class='inline' href="{{ url_for('dashboard_clone', uuid=dashboard.id) }}">Clone</a>
+          </li>
+        </ul>
+      </li>
     {% endfor %}
   </ul>
 {% endif %}


### PR DESCRIPTION
Introduces a clone link next to each existing dashboard in the tool. When clicked, a 'create a dashboard' form is rendered, pre-filled with data from the 'cloned' dashboard. For consistency, also replaced the <a> tag around the dashboard title in the dashboard list (for editing a dashboard) with an 'edit' link. 

See https://www.agileplannerapp.com/boards/15088/cards/8789 for more info.