### PR TITLE
Set published flag to False for cloned dashboards

### DIFF
--- a/admin/dashboards.py
+++ b/admin/dashboards.py
@@ -160,6 +160,7 @@ def dashboard_clone(admin_client):
         dashboard_dict, admin_client, ModuleTypes())
     form['title'].data = ''
     form['slug'].data = ''
+    form['published'].data = False
     for m in form.modules:
         m['id'].data = ''
     return render_template('dashboards/create.html',

--- a/tests/admin/test_dashboards.py
+++ b/tests/admin/test_dashboards.py
@@ -566,6 +566,7 @@ class DashboardTestCase(FlaskAppTestCase):
         assert_that(form.strapline.data, equal_to(dashboard_dict['strapline']))
         assert_that(form['title'].data, equal_to(''))
         assert_that(form['slug'].data, equal_to(''))
+        assert_that(form['published'].data, equal_to(False))
         for m in form.modules:
             assert_that(m['id'].data, equal_to(''))
         assert_that(resp.status_code, equal_to(200))


### PR DESCRIPTION
FIX: Always set the published flag to False when cloning a dashboard in case the cloned dashboard is published.