### PR TITLE
Implement support for signonotron callbacks

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -26,7 +26,7 @@ app.session_interface = RedisSessionInterface(
 # this will only send when SENTRY_DSN is defined in config
 Sentry(app)
 
-CsrfProtect(app)
+csrf = CsrfProtect(app)
 
 log_handler.set_up_logging(app, GOVUK_ENV)
 

--- a/admin/authentication.py
+++ b/admin/authentication.py
@@ -1,7 +1,7 @@
 from admin import app, csrf
 from flask import redirect, request, session, url_for, flash
 from requests_oauthlib import OAuth2Session
-from helpers import api_permission_required
+from helpers import api_permission_required, get_admin_client
 
 
 def get_authorization_url(session):
@@ -109,4 +109,5 @@ def reauth(uid):
         403 on failure, as the user didn't have the correct permissions.
     """
     session.delete_sessions_for_user(uid)
+    get_admin_client(session).reauth(uid)
     return ''

--- a/admin/authentication.py
+++ b/admin/authentication.py
@@ -1,6 +1,7 @@
-from admin import app
+from admin import app, csrf
 from flask import redirect, request, session, url_for, flash
 from requests_oauthlib import OAuth2Session
+from helpers import api_permission_required
 
 
 def get_authorization_url(session):
@@ -50,3 +51,62 @@ def authorize():
     session['oauth_token'] = token
 
     return redirect(url_for('root'))
+
+
+@app.route("/auth/gds/api/users/<uid>", methods=['PUT'])
+@csrf.exempt
+@api_permission_required('user_update_permission')
+def update(uid):
+    """Update a user, triggered by sign-on-o-tron
+
+    When a user is updated in sign-on-o-tron, sign-on-o-tron
+    will send a PUT request to the url of this controller, with a
+    bearer token of the user that sends the request. The user which sends the
+    request is specified by the sidekiq queue that sends the notifications from
+    sign-on-o-tron. To ensure the request has come from sign-on-o-tron, we use
+    this bearer token as an auth token and request the properties of the user -
+    we only allow the request if the user has the user_update_permission.
+
+    After authenticating the request, we read the JSON request body and update
+    the stored representation of the user in our app, if present.
+
+    Following the model in gds-sso, we return a 200 if succesful.
+
+    Args:
+        uid: a sign-on-o-tron user_id
+
+    Returns:
+        200 on success
+    """
+    # For now, we implement this as a no-op
+    return ''
+
+
+@app.route("/auth/gds/api/users/<uid>/reauth", methods=['POST'])
+@csrf.exempt
+@api_permission_required('user_update_permission')
+def reauth(uid):
+    """ Force a user to reauth, triggered by sign-on-o-tron
+
+    When a user signs out of sign-on-o-tron or is suspended, sign-on-o-tron
+    will send an empty post request to the url of this controller, with a
+    bearer token of the user that sends the request. The user which sends the
+    request is specified by the sidekiq queue that sends the notifications from
+    sign-on-o-tron. To ensure the request has come from sign-on-o-tron, we use
+    this bearer token as an auth token and request the properties of the user -
+    we only allow the request if the user has the user_update_permission.
+
+    After authenticating the request, we delete all sessions for the user in
+    redis, with the effect they will no longer be able to login to the admin
+    app. Following gds-sso, we return a 200 if sucessful, despite this being a
+    post request.
+
+    Args:
+        uid: a sign-on-o-tron user_id
+
+    Returns:
+        200 on success
+        403 on failure, as the user didn't have the correct permissions.
+    """
+    session.delete_sessions_for_user(uid)
+    return ''

--- a/admin/helpers.py
+++ b/admin/helpers.py
@@ -81,6 +81,10 @@ def api_permission_required(permission=None):
                 abort(401, 'invalid access token.')
 
             if permission in user['user']['permissions']:
+                session['oauth_user'] = user['user']
+                session['oauth_token'] = {
+                    'access_token': access_token
+                }
                 return f(*args, **kwargs)
             else:
                 abort(403, 'user lacks permission.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2
-performanceplatform-client==0.2.5
+performanceplatform-client==0.7.0
 pyasn1==0.1.7
 pyOpenSSL==0.14
 pytz==2014.4


### PR DESCRIPTION
When a user is suspended in signon, client apps can receive
notifications of these events.

We should handle these, so that people are logged out as appropriate.

This change handles the session state for the UI, which is what we care
about in this instance. There is a corresponding change in pp-puppet to
ensure that the request is handled by this application, rather than
being proxied through to stagecraft.

This fixes the bug where only clearing the session in stagecraft wasn’t
logging actual users out of the admin UI.