### PR TITLE
Apply for a dashboard

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -34,6 +34,7 @@ log_handler.set_up_logging(app, GOVUK_ENV)
 import admin.main
 import admin.authentication
 import admin.dashboards
+import admin.registrations
 import admin.transforms
 import admin.upload
 

--- a/admin/assets/scss/performanceplatform-admin/style.scss
+++ b/admin/assets/scss/performanceplatform-admin/style.scss
@@ -47,3 +47,27 @@ ul.links {
 textarea.json-field {
   height: 10em;
 }
+
+.hint {
+  color: $gray-light;
+}
+
+.form-group p.hint {
+  margin-bottom: 0;
+}
+
+.confirmation-box {
+  background-color: #6F9B95;
+  color: #FFF;
+  text-align: center;
+  padding: 10px;
+
+  h1 {
+    margin-top: 10px;
+    font-weight: normal;
+
+    span.glyphicon {
+      font-size: 75%;
+    }
+  }
+}

--- a/admin/config/development.py
+++ b/admin/config/development.py
@@ -29,6 +29,11 @@ FAKE_OAUTH_USER = {
     "uid": "00000000-0000-0000-0000-000000000000"
 }
 
+AWS_ACCESS_KEY_ID = 'AWS access key id'
+AWS_SECRET_ACCESS_KEY = 'AWS secret access key'
+NOTIFICATIONS_EMAIL = 'notifications@performance.service.gov.uk'
+NO_REPLY_EMAIL = 'no-reply@performance.service.gov.uk'
+
 # You can use development_local_overrides.py in this directory to set config
 # that is unique to your development environment, like OAuth IDs and secrets.
 # It is not in version control.

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -129,7 +129,8 @@ def get_organisation_choices(admin_client):
     choices = [('', '')]
 
     try:
-        organisations = admin_client.list_organisations()
+        organisations = admin_client.list_organisations(
+            {'type': ['department', 'agency']})
         choices += [
             (org['id'], org['name']) for org in organisations]
         choices.sort(key=lambda tup: tup[1])

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -1,7 +1,9 @@
 from admin import app
 from admin.fields.json_textarea import JSONTextAreaField
+from flask_wtf import Form as FlaskWTFForm
 from wtforms import (FieldList, Form, FormField, TextAreaField, TextField,
-                     HiddenField, validators)
+                     HiddenField)
+from wtforms.validators import Required, Email, URL, Optional
 from wtforms_components.fields.select import SelectField
 import requests
 import json
@@ -172,7 +174,7 @@ class DashboardCreationForm(Form):
     description = TextField('Description')
     owning_organisation = SelectField(
         'Owning organisation',
-        [validators.Required(message='This field cannot be blank.')]
+        validators=[Required(message='This field cannot be blank.')]
     )
     customer_type = SelectField('Customer type', choices=[
         ('', ''),
@@ -194,3 +196,41 @@ class DashboardCreationForm(Form):
 
     modules = FieldList(FormField(ModuleForm), min_entries=0)
     published = HiddenField('published', default=False)
+
+
+class AboutYouForm(FlaskWTFForm):
+
+    def __init__(self, admin_client, *args, **kwargs):
+        super(AboutYouForm, self).__init__(*args, **kwargs)
+        self.organisation.choices = get_organisation_choices(
+            admin_client)
+        self.organisation.choices[0] = ('', 'Select a department or agency')
+
+    full_name = TextField(
+        'Full name',
+        validators=[Required(message='Name cannot be blank')])
+    email_address = TextField(
+        'Email address',
+        validators=[
+            Required(message='Email cannot be blank'),
+            Email(message='Email format is invalid')
+        ])
+    organisation = SelectField(
+        'Your organisation',
+        validators=[Required(message='Organisation cannot be blank')]
+    )
+
+
+class AboutYourServiceForm(FlaskWTFForm):
+    service_name = TextField(
+        'Service name',
+        validators=[Required(message='Name cannot be blank')])
+    service_url = TextField(
+        'Service start page URL',
+        validators=[
+            Optional(),
+            URL(message='Start page URL format is invalid')
+        ])
+    service_description = TextAreaField(
+        'Service description',
+        validators=[Required(message='Service description cannot be blank')])

--- a/admin/registrations.py
+++ b/admin/registrations.py
@@ -1,0 +1,108 @@
+from flask import (session, render_template, url_for, flash, redirect)
+import boto.ses
+from admin import app
+from performanceplatform.client.admin import AdminAPI
+from admin.forms import AboutYouForm, AboutYourServiceForm
+from admin.helpers import base_template_context
+
+REGISTER_ROUTE = '/register'
+
+
+@app.route('{0}'.format(REGISTER_ROUTE), methods=['GET'])
+def start():
+    template_context = base_template_context()
+    return render_template('registrations/start.html', **template_context)
+
+
+@app.route('{0}/about-you'.format(REGISTER_ROUTE), methods=['GET', 'POST'])
+def about_you():
+    admin_client = AdminAPI(app.config['STAGECRAFT_HOST'], None)
+    form = AboutYouForm(admin_client)
+    template_context = base_template_context()
+    if form.validate_on_submit():
+        session['full_name'] = form.data['full_name']
+        session['email_address'] = form.data['email_address']
+        session['organisation_name'] = get_organisation_name(
+            form.data['organisation'], form.organisation.choices)
+        return redirect(url_for('about_your_service'))
+    if form.errors:
+        flash(to_error_list(form.errors), 'danger')
+    return render_template(
+        'registrations/about-you.html',
+        form=form,
+        **template_context)
+
+
+def get_organisation_name(uuid, choices):
+    return [i[1] for i in choices if i[0] == uuid][0]
+
+
+@app.route('{0}/about-your-service'.format(REGISTER_ROUTE),
+           methods=['GET', 'POST'])
+def about_your_service():
+    form = AboutYourServiceForm()
+    template_context = base_template_context()
+    if form.validate_on_submit():
+        session['service_name'] = form.data['service_name']
+        session['service_url'] = form.data['service_url']
+        session['service_description'] = form.data['service_description']
+        send_application_email()
+        return redirect(url_for('confirmation'))
+    if form.errors:
+        flash(to_error_list(form.errors), 'danger')
+    return render_template(
+        'registrations/about-your-service.html',
+        form=form,
+        **template_context)
+
+
+def send_application_email():
+    conn = boto.ses.connect_to_region(
+        'us-east-1',
+        aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'])
+
+    body_text = (
+        "Full name: {0}\n\n"
+        "Email address: {1}\n\n"
+        "Organisation name: {2}\n\n"
+        "Service name: {3}\n\n"
+        "Service URL: {4}\n\n"
+        "Service description:\n{5}").format(
+            session['full_name'],
+            session['email_address'],
+            session['organisation_name'],
+            session['service_name'],
+            session['service_url'],
+            session['service_description'])
+
+    conn.send_email(
+        app.config['NO_REPLY_EMAIL'],
+        'New dashboard application',
+        body_text,
+        app.config['NOTIFICATIONS_EMAIL'],
+        reply_addresses=app.config['NO_REPLY_EMAIL'])
+
+
+@app.route('{0}/confirmation'.format(REGISTER_ROUTE), methods=['GET'])
+def confirmation():
+    session.pop('full_name', None)
+    session.pop('email_address', None)
+    session.pop('organisation_name', None)
+    session.pop('service_name', None)
+    session.pop('service_url', None)
+    session.pop('service_description', None)
+    template_context = base_template_context()
+    return render_template(
+        'registrations/confirmation.html',
+        **template_context)
+
+
+def to_error_list(form_errors):
+    def format_error(error):
+        return '{0}'.format(error)
+
+    messages = []
+    for field_name, field_errors in form_errors.items():
+        messages.append('; '.join(map(format_error, field_errors)))
+    return 'You have errors in your form: ' + '; '.join(messages) + '.'

--- a/admin/templates/navbar/nav.html
+++ b/admin/templates/navbar/nav.html
@@ -22,6 +22,9 @@
         <ul class="nav navbar-nav">
           {% if not user %}
             <li>
+              <a href="/register" title="Apply for a dashboard">Apply for a dashboard</a>
+            </li>
+            <li>
               <a href="/login" title="Sign in">Sign in</a>
             </li>
           {% endif %}

--- a/admin/templates/registrations/about-you.html
+++ b/admin/templates/registrations/about-you.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h1>About you</h1>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    We will use these details to check your eligibility for a performance
+    dashboard and create you a GOV.UK Signon account with a template
+    dashboard into which you can add your data.
+  </p>
+</div>
+
+<form method="POST" action="{{ url_for('about_you') }}" role="form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.full_name.label }}
+      {{ form.full_name(class='form-control') }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.email_address.label }}
+      {{ form.email_address(class='form-control') }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.organisation.label }}
+      {{ form.organisation(class='form-control') }}
+    </div>
+  </div>
+
+  <input type="submit" class="btn btn-success" value="Continue" name="continue">
+</form>
+
+{% endblock %}

--- a/admin/templates/registrations/about-your-service.html
+++ b/admin/templates/registrations/about-your-service.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h1>About your service</h1>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    We will use these details to check your eligibilty for a performance
+    dashboard and create you a template dashboard into which you can add
+    and edit your data.
+  </p>
+</div>
+
+<form method="POST" action="{{ url_for('about_your_service') }}" role="form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.service_name.label }}
+      {{ form.service_name(class='form-control') }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.service_url.label }}
+      <span class="hint">(optional)</span>
+      <p class="hint">Start your URL with http:// or https://</p>
+      {{ form.service_url(class='form-control') }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-sm-8 col-md-6">
+      {{ form.service_description.label }}
+      <span class="hint">(Max 200 words)</span>
+      {{ form.service_description(class='form-control', rows='4') }}
+    </div>
+  </div>
+
+  <div class="row callout">
+    <p class="col-sm-8 col-md-6">
+      This description shall appear at the bottom of your dashboard</br>
+      <a href="https://www.gov.uk/performance/standard-dashboard">Take a look an example</a>
+    </p>
+  </div>
+
+  <div class="row">
+    <p class="col-sm-8 col-md-6">
+      These details shall be reviewed and possibly amended by our content
+      designers before your template dashboard is created. You will have
+      the opportunity to amend any changes made by our team.
+    </p>
+  </div>
+
+  <input type="submit" class="btn btn-success" value="Submit application" name="submit-application">
+</form>
+
+{% endblock %}

--- a/admin/templates/registrations/confirmation.html
+++ b/admin/templates/registrations/confirmation.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<div class="row">
+  <div class="col-sm-8 col-md-6">
+    <div class="confirmation-box">
+      <h1 class="h3">
+        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+        Application submitted
+      </h1>
+      <p>We'll email you when your account and dashboard are set up</p>
+    </div>
+  </div>
+</div>
+
+<h2 class="h4">What happens next</h2>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    We will use these details to check your eligibility for a performance
+    dashboard and create you a GOV.UK Signon account with a template
+    dashboard into which you can add your data.
+  </p>
+</div>
+
+{% endblock %}

--- a/admin/templates/registrations/start.html
+++ b/admin/templates/registrations/start.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h1>Apply for a dashboard</h1>
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    <big>
+      If you own or work on a transactional service on GOV.UK,
+      you can now get a performance dashboard for it displaying the
+      <a href="https://www.gov.uk/service-manual/measurement">4 digital KPIs</a>
+      (key performance indicators) for your service as required by the
+      <a href="https://www.gov.uk/service-manual/digital-by-default">service standard</a>.
+    </big>
+  </p>
+</div>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    You will need to send us basic details about you and your service and
+    within 3 days we shall email you with a login to our Get a dashboard service.
+  </p>
+</div>
+
+<div class="row callout">
+  <p class="col-sm-8 col-md-6">
+    The details about you and your service shall be reviewed by the
+    Performance Platform team who shall the set up a GOV.UK Signon
+    account for your dashboard and email you with login details
+    within 3 working days.
+  </p>
+</div>
+
+<p>
+  When you're done, your dashboard will look like
+  <a href="https://www.gov.uk/performance/standard-dashboard">this example</a>.
+</p>
+
+<p>
+  <a href="{{ url_for('about_you') }}" class="btn btn-success btn-lg">Apply now</a>
+</p>
+
+<h2 class="h4">About the 4 digital KPIs</h2>
+
+<p>The 4 digital KPIs are part of the
+  <a href="https://www.gov.uk/service-manual">Digital Service Design Manual</a>.
+</p>
+
+<p>They are:</p>
+<ul>
+  <li>Admin cost per user</li>
+  <li>Digital take-up</li>
+  <li>User satisfaction</li>
+  <li>Completion rate</li>
+</ul>
+
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2
-performanceplatform-client==0.7.0
+performanceplatform-client==0.8.0
 pyasn1==0.1.7
 pyOpenSSL==0.14
 pytz==2014.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests==2.3.0
 requests-oauthlib==0.4.1
 pyScss==1.2.0
 xlrd==0.9.3
+boto==2.36.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -12,4 +12,4 @@ if [ -z "$NO_AUTOPEP8" ]; then
   autopep8 -i -r admin tests
 fi
 
-pep8 --exclude=venv "$basedir"
+pep8 --exclude=venv,build "$basedir"

--- a/tests/admin/test_registrations.py
+++ b/tests/admin/test_registrations.py
@@ -1,0 +1,194 @@
+from tests.admin.support.flask_app_test_case import FlaskAppTestCase
+from mock import patch
+from hamcrest import (assert_that, equal_to, contains_string,
+                      ends_with)
+from admin import app
+
+
+class StartPageTestCase(FlaskAppTestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+
+    def test_register_slug_renders_start_page(self):
+        response = self.app.get('/register')
+        assert_that(response.status, equal_to('200 OK'))
+
+
+def organisations_list():
+    return [{'id': 'organisation-uuid', 'name': 'Mock organisation'}]
+
+
+@patch("performanceplatform.client.admin.AdminAPI.list_organisations",
+       return_value=organisations_list())
+class AboutYouPageTestCase(FlaskAppTestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        app.config['WTF_CSRF_ENABLED'] = False
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'full_name': 'Foo Bar',
+            'email_address': 'foo@example.com',
+            'organisation': 'organisation-uuid'
+        }
+        params.update(options)
+        return params
+
+    def test_about_you_slug_renders_about_you_page(
+            self, mock_list_organisations):
+        response = self.app.get('/register/about-you')
+        assert_that(response.status, equal_to('200 OK'))
+
+    def test_full_name_field_is_required(self, mock_list_organisations):
+        data = self.params({'full_name': ''})
+        response = self.app.post('/register/about-you', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data, contains_string('Name cannot be blank'))
+
+    def test_email_address_field_is_required(self, mock_list_organisations):
+        data = self.params({'email_address': ''})
+        response = self.app.post('/register/about-you', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data, contains_string('Email cannot be blank'))
+
+    def test_email_address_is_like_an_email_address(
+            self, mock_list_organisations):
+        data = self.params({'email_address': 'foo.example.com'})
+        response = self.app.post('/register/about-you', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data, contains_string('Email format is invalid'))
+
+    def test_organisation_field_is_required(self, mock_list_organisations):
+        data = self.params({'organisation': ''})
+        response = self.app.post('/register/about-you', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(
+            response.data, contains_string('Organisation cannot be blank'))
+
+    def test_stores_submitted_data_in_the_session(
+            self, mock_list_organsations):
+        self.client.post('/register/about-you', data=self.params())
+        self.assert_session_contains('full_name', 'Foo Bar')
+        self.assert_session_contains('email_address', 'foo@example.com')
+        self.assert_session_contains('organisation_name', 'Mock organisation')
+
+    def test_redirects_to_about_your_service_page(
+            self, mock_list_organisations):
+        response = self.app.post('/register/about-you', data=self.params())
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/about-your-service'))
+
+
+@patch("boto.ses.connect_to_region")
+class AboutYourServicePageTestCase(FlaskAppTestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        app.config['WTF_CSRF_ENABLED'] = False
+        with self.client.session_transaction() as session:
+            session['full_name'] = 'Foo Bar'
+            session['email_address'] = 'foo@example.com'
+            session['organisation_name'] = 'Mock organisation'
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'service_name': 'Foo',
+            'service_url': '',
+            'service_description': 'All about foo'
+        }
+        params.update(options)
+        return params
+
+    def test_service_name_field_is_required(self, mock_ses_connection):
+        data = self.params({'service_name': ''})
+        response = self.client.post('/register/about-your-service', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data, contains_string('Name cannot be blank'))
+
+    def test_service_url_field_is_optional(self, mock_ses_connection):
+        data = self.params()
+        response = self.client.post('/register/about-your-service', data=data)
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_service_url_is_like_a_url(self, mock_ses_connection):
+        data = self.params({'service_url': 'www.foo..com'})
+        response = self.client.post('/register/about-your-service', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data,
+                    contains_string('Start page URL format is invalid'))
+
+    def test_service_description_field_is_required(self, mock_ses_connection):
+        data = self.params({'service_description': ''})
+        response = self.client.post('/register/about-your-service', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data,
+                    contains_string('Service description cannot be blank'))
+
+    def test_stores_submitted_data_in_the_session(self, mock_ses_connection):
+        self.client.post('/register/about-your-service', data=self.params())
+        self.assert_session_contains('service_name', 'Foo')
+        self.assert_session_contains('service_url', '')
+        self.assert_session_contains('service_description', 'All about foo')
+
+    def test_sends_details_of_the_application_by_email(
+            self, mock_ses_connection):
+        data = self.params({'service_url': 'http://www.foo.com'})
+        self.client.post('/register/about-your-service', data=data)
+        second_call_args = mock_ses_connection.mock_calls[1][1]
+        assert_that(second_call_args[0],
+                    equal_to(app.config['NO_REPLY_EMAIL']))
+        assert_that(second_call_args[1], equal_to('New dashboard application'))
+        assert_that(second_call_args[2],
+                    contains_string('Full name: Foo Bar\n'))
+        assert_that(second_call_args[2],
+                    contains_string('Email address: foo@example.com\n'))
+        assert_that(second_call_args[2],
+                    contains_string('Organisation name: Mock organisation\n'))
+        assert_that(second_call_args[2],
+                    contains_string('Service name: Foo\n'))
+        assert_that(second_call_args[2],
+                    contains_string('Service URL: http://www.foo.com\n'))
+        assert_that(second_call_args[2],
+                    contains_string('Service description:\nAll about foo'))
+        assert_that(
+            second_call_args[3],
+            equal_to(app.config['NOTIFICATIONS_EMAIL']))
+
+    def test_redirects_to_confirmation_page(self, mock_ses_connection):
+        data = self.params()
+        response = self.client.post('/register/about-your-service', data=data)
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/confirmation'))
+
+
+class ConfirmationPageTestCase(FlaskAppTestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+
+    def test_confirmation_slug_renders_confirmation_page(self):
+        response = self.app.get('/register/confirmation')
+        assert_that(response.status, equal_to('200 OK'))
+
+    def test_resets_session_data(self):
+        app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+        with self.client.session_transaction() as session:
+            session['full_name'] = ''
+            session['email_address'] = ''
+            session['organisation_name'] = ''
+            session['service_name'] = ''
+            session['service_url'] = ''
+            session['service_description'] = ''
+        self.client.get('/register/confirmation')
+        self.assert_session_does_not_contain('full_name')
+        self.assert_session_does_not_contain('email_address')
+        self.assert_session_does_not_contain('organisation_name')
+        self.assert_session_does_not_contain('service_name')
+        self.assert_session_does_not_contain('service_url')
+        self.assert_session_does_not_contain('service_description')


### PR DESCRIPTION
Users can apply for a dashboard by completing a 2-form application process rooted at /register. It is not necessary for the user to have a sign-on account.

On submission of their application, their details are emailed to notifcations@performance.service.gov.uk via AWS SES. For this reason, this pull request is dependent on https://github.gds/gds/pp-deployment/pull/457

Story: https://www.agileplannerapp.com/boards/15088/cards/9385