### PR TITLE
Make dashboard hub page

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -35,6 +35,7 @@ import application.controllers.main
 import application.controllers.authentication
 import application.controllers.admin.dashboards
 import application.controllers.registrations
+import application.controllers.dashboards
 import application.controllers.admin.transforms
 import application.controllers.upload
 

--- a/application/assets/scss/performanceplatform-admin/style.scss
+++ b/application/assets/scss/performanceplatform-admin/style.scss
@@ -10,6 +10,10 @@
   }
 }
 
+h1 {
+  margin-top: 0;
+}
+
 ul.links {
   padding-left: 0;
   display: inline;
@@ -38,6 +42,12 @@ ul.links {
   margin-bottom: 13px;
 }
 
+.keyline-separator {
+  border-bottom: 1px solid $gray-light;
+  margin-bottom: 5px;
+  padding-bottom: 50px;
+}
+
 #admin-footer {
   border-top: 1px solid #999;
   margin-top: 3em;
@@ -54,6 +64,16 @@ textarea.json-field {
 
 .form-group p.hint {
   margin-bottom: 0;
+}
+
+.side-hint-md {
+  color: $gray-light;
+  margin-bottom: 0;
+
+  @media (min-width: 992px) {
+    float: right;
+    margin-top: 5px;
+  }
 }
 
 .confirmation-box {

--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -1,0 +1,43 @@
+from application import app
+from collections import namedtuple
+from application.forms import DashboardHubForm
+from flask import (
+    render_template,
+    redirect,
+    url_for,
+    flash
+)
+from application.helpers import (
+    base_template_context,
+    requires_authentication,
+    requires_permission,
+    to_error_list
+)
+
+
+DASHBOARD_ROUTE = '/dashboards'
+
+
+@app.route('{0}/<uuid>'.format(DASHBOARD_ROUTE), methods=['GET', 'POST'])
+@requires_authentication
+@requires_permission('dashboard')
+def dashboard_hub(admin_client, uuid):
+    template_context = base_template_context()
+    dashboard_dict = admin_client.get_dashboard(uuid)
+    Dashboard = namedtuple('Dashboard', dashboard_dict.keys())
+    dashboard = Dashboard(**dashboard_dict)
+    form = DashboardHubForm(obj=dashboard)
+    if form.validate_on_submit():
+        admin_client.update_dashboard(uuid, form.data)
+        return redirect(url_for('dashboard_admin_index'))
+    if form.errors:
+        flash(to_error_list(form.errors), 'danger')
+    preview_url = "{0}/performance/{1}".format(
+        app.config['GOVUK_SITE_URL'], dashboard_dict['slug'])
+    return render_template(
+        'dashboards/dashboard-hub.html',
+        uuid=uuid,
+        dashboard_title=dashboard.title,
+        preview_url=preview_url,
+        form=form,
+        **template_context)

--- a/application/controllers/registrations.py
+++ b/application/controllers/registrations.py
@@ -3,7 +3,7 @@ import boto.ses
 from application import app
 from performanceplatform.client.admin import AdminAPI
 from application.forms import AboutYouForm, AboutYourServiceForm
-from application.helpers import base_template_context
+from application.helpers import base_template_context, to_error_list
 
 REGISTER_ROUTE = '/register'
 
@@ -96,13 +96,3 @@ def confirmation():
     return render_template(
         'registrations/confirmation.html',
         **template_context)
-
-
-def to_error_list(form_errors):
-    def format_error(error):
-        return '{0}'.format(error)
-
-    messages = []
-    for field_name, field_errors in form_errors.items():
-        messages.append('; '.join(map(format_error, field_errors)))
-    return 'You have errors in your form: ' + '; '.join(messages) + '.'

--- a/application/forms.py
+++ b/application/forms.py
@@ -235,3 +235,12 @@ class AboutYourServiceForm(FlaskWTFForm):
     service_description = TextAreaField(
         'Service description',
         validators=[Required(message='Service description cannot be blank')])
+
+
+class DashboardHubForm(FlaskWTFForm):
+    title = TextField(
+        'Dashboard title',
+        validators=[Required(message='Title cannot be blank')])
+    description = TextAreaField(
+        'Dashboard description',
+        validators=[Required(message='Description cannot be blank')])

--- a/application/helpers.py
+++ b/application/helpers.py
@@ -181,3 +181,13 @@ def _get_user(token):
         return user_request.json()
     except ValueError:
         abort(500, 'Unable to parse signon json')
+
+
+def to_error_list(form_errors):
+    def format_error(error):
+        return '{0}'.format(error)
+
+    messages = []
+    for field_name, field_errors in form_errors.items():
+        messages.append('; '.join(map(format_error, field_errors)))
+    return 'You have errors in your form: ' + '; '.join(messages) + '.'

--- a/application/templates/dashboards/dashboard-hub.html
+++ b/application/templates/dashboards/dashboard-hub.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<section>
+  <header class="keyline-separator">
+    <span class="hint">Your dashboard</span>
+    <h1>{{ dashboard_title }}</h1>
+    <small>Manage the data and content displayed on your dashboard</small>
+  </header>
+
+  <section class="keyline-separator">
+    <header>
+      <h1>About the dashboard</h1>
+    </header>
+
+    <form method="POST" action="{{ url_for('dashboard_hub', uuid=uuid) }}" role="form">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+      <div class="form-group">
+        {{ form.title.label }}
+        <div class="row">
+          <p class="col-sm-12 col-md-6 side-hint-md">
+            The name that will be shown at the top of your dashboard
+          </p>
+          <div class="col-sm-12 col-md-6">
+            {{ form.title(class='form-control') }}
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        {{ form.description.label }}
+        <div class="row">
+          <p class="col-sm-12 col-md-6 side-hint-md">
+            The description that will be show at the bottom of your dashboard
+          </p>
+          <div class="col-sm-12 col-md-6">
+            {{ form.description(class='form-control') }}
+          </div>
+        </div>
+      </div>
+
+      <input type="submit" class="btn btn-success" value="Update dashboard" name="submit-dashboard">
+    </form>
+  </section>
+
+  <section class="keyline-separator">
+    <header>
+      <h1>Dashboard data</h1>
+    </header>
+
+    <ul>
+    </ul>
+  </section>
+
+  <footer>
+    <p>
+      <a href="{{ preview_url }}" class="btn btn-info" target="_blank">Preview dashboard</a>
+    </p>
+  </footer>
+</section>
+
+{% endblock %}

--- a/tests/application/controllers/test_dashboards.py
+++ b/tests/application/controllers/test_dashboards.py
@@ -1,0 +1,120 @@
+from tests.application.support.flask_app_test_case import FlaskAppTestCase
+from application import app
+from mock import patch
+from hamcrest import (
+    assert_that,
+    contains_string,
+    equal_to,
+    has_entries
+)
+import os
+import json
+
+
+def dashboard_data(options={}):
+    params = {
+        'id': 'uuid',
+        'title': 'A dashboard',
+        'description': 'All about this dashboard',
+        'slug': 'valid-slug',
+        'owning_organisation': 'organisation-uuid',
+        'dashboard_type': 'transaction',
+        'customer_type': 'Business',
+        'strapline': 'Dashboard',
+        'business_model': 'Department budget'
+    }
+    params.update(options)
+    return params
+
+
+class DashboardHubPageTestCase(FlaskAppTestCase):
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'title': 'Foo Bar',
+            'description': 'All about Foo Bar'
+        }
+        params.update(options)
+        return params
+
+    def setUp(self):
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'dashboard']
+            }
+
+    def test_authenticated_user_is_required(self):
+        with self.client.session_transaction() as session:
+            del session['oauth_token']
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_authorised_user_is_required(self):
+        with self.client.session_transaction() as session:
+            session['oauth_user'] = {'permissions': ['signin']}
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_dashboard_edit_slug_renders_dashboard_hub_page(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.status, equal_to('200 OK'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_dashboard_is_fetched(self, mock_get_dashboard):
+        self.client.get('/dashboards/dashboard-uuid')
+        mock_get_dashboard.assert_called_once_with('dashboard-uuid')
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")
+    def test_dashboard_is_rendered(self, mock_get_dashboard):
+        with open(os.path.join(
+                  os.path.dirname(__file__),
+                  '../../fixtures/example-self-serve-dashboard.json')) as file:
+            dashboard_json = file.read()
+        dashboard_dict = json.loads(dashboard_json)
+        mock_get_dashboard.return_value = dashboard_dict
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.data, contains_string('Patent renewals'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_dashboard_title_field_is_required(self, mock_get_dashboard):
+        data = self.params({'title': ''})
+        response = self.client.post('/dashboards/uuid', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data, contains_string('Title cannot be blank'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_dashboard_description_field_is_required(self, mock_get_dashboard):
+        data = self.params({'description': ''})
+        response = self.client.post('/dashboards/uuid', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(
+            response.data, contains_string('Description cannot be blank'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
+    def test_dashboard_is_updated(
+            self, mock_update_dashboard, mock_get_dashboard):
+        data = self.params()
+        self.client.post('/dashboards/uuid', data=data)
+        post_json = mock_update_dashboard.call_args[0][1]
+        assert_that(mock_update_dashboard.call_args[0][0], equal_to('uuid'))
+        assert_that(post_json, has_entries(data))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_renders_a_link_for_previewing_the_dashboard(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
+        url = '{0}/performance/valid-slug'.format(app.config['GOVUK_SITE_URL'])
+        assert_that(response.data, contains_string(url))

--- a/tests/fixtures/example-self-serve-dashboard.json
+++ b/tests/fixtures/example-self-serve-dashboard.json
@@ -1,0 +1,123 @@
+{
+ "description_extra": "",
+ "strapline": "Dashboard",
+ "description": "To protect your intellectual property, you must renew your patents on the 4th anniversary of the filing date and every year after that.",
+ "links": [
+  {
+   "url": "https://www.gov.uk/renew-patent",
+   "type": "transaction",
+   "title": "Renew a patent"
+  }
+ ],
+ "title": "Patent renewals",
+ "tagline": "",
+ "organisation": {
+  "abbreviation": "Intellectual Property Office",
+  "type": {
+   "id": "2d4364e3-153h-44ad-855c-e329127de094",
+   "name": "department"
+  },
+  "id": "590110d6-acde-4a4b-bcd6-60f607965252",
+  "parent": null,
+  "name": "Intellectual Property Office"
+ },
+ "modules": [
+  {
+   "description": "",
+   "data_type": "summaries",
+   "id": "386537d1-5e91-47b7-8213-ed93d1a68792",
+   "data_group": "transactional-services",
+   "info": [],
+   "title": "Cost per transaction",
+   "query_parameters": {
+    "sort_by": "_timestamp:descending",
+    "filter_by": [
+     "service_id:bis-payment-of-patent-renewal-fee-f12",
+     "type:seasonally-adjusted"
+    ]
+   },
+   "slug": "cost-per-transaction",
+   "dashboard": {
+    "id": "06f3dc23-77be-4d63-a0df-618e856d6216"
+   },
+   "type": {
+    "id": "35b41563-2773-487c-9830-c912d74adda7"
+   },
+   "options": {
+    "classes": "cols3",
+    "value-attribute": "cost_per_transaction",
+    "format": {
+     "pence": true,
+     "type": "currency"
+    }
+   }
+  },
+  {
+   "description": "Overall satisfaction score includes all ratings weighted from 100% for 'very satisfied' to 0% for 'very dissatisfied'",
+   "data_type": "user-satisfaction-score",
+   "id": "24068637-e2d5-420b-9144-6898a1dd622e",
+   "data_group": "renew-patent",
+   "info": [
+    "Data source: GOV.UK user feedback database",
+    "<a href='/service-manual/measurement/user-satisfaction' rel='external'>User satisfaction</a> is measured by surveying users at the point of transaction completion. It is measured on a five-point scale, from most satisfied to least satisfied. The mean of these responses is converted to a percentage for display purposes."
+   ],
+   "title": "User satisfaction",
+   "query_parameters": {
+    "sort_by": "_timestamp:ascending"
+   },
+   "slug": "user-satisfaction",
+   "dashboard": {
+    "id": "06f3dc23-77be-4d63-a0df-618e856d6216"
+   },
+   "type": {
+    "id": "3ad885d9-62cc-45d0-85bb-c0b52ea3f8f9"
+   },
+   "options": {}
+  },
+  {
+   "description": "Proportion of renewals made using the digital service",
+   "data_type": "digital-takeup",
+   "id": "24068637-e2de-420c-9144-6898a0dd622e",
+   "data_group": "patent-renewal",
+   "info": [
+    "Data source: Intellectual Property Office",
+    "<a href='/service-manual/measurement/digital-takeup' rel='external'>Digital take-up</a> measures the percentage of completed monthly renewals that are made through online and bulk software versus non-digital channels."
+   ],
+   "title": "Digital take-up",
+   "query_parameters": {
+    "sort_by": "_timestamp:ascending"
+   },
+   "slug": "digital-take-up-per-quarter",
+   "dashboard": {
+    "id": "06f3dc23-77be-4d63-a0df-618e856d6216"
+   },
+   "type": {
+    "id": "3ad885d9-62cc-45d0-85bb-c0b52ea3f8f9"
+   },
+   "options": {
+    "value-attribute": "rate",
+    "axis-period": "quarter",
+    "axes": {
+     "y": [
+      {
+       "label": "Percentage digital take-up"
+      }
+     ]
+    },
+    "format": {
+     "type": "percent"
+    }
+   }
+  }
+ ],
+ "dashboard_type": "transaction",
+ "slug": "renew-patent",
+ "improve_dashboard_message": true,
+ "customer_type": "Business",
+ "costs": "These costs are based on our fee charges data produced for 2010 to 2011 and exclude policy cost.",
+ "page_type": "dashboard",
+ "published": false,
+ "business_model": "Fees and charges",
+ "id": "06f3dc23-77be-4d63-a0df-618e856d6216",
+ "other_notes": ""
+}


### PR DESCRIPTION
Basic dashboard hub page for self-serve features of the admin app - see https://www.pivotaltracker.com/story/show/89863012. Note that this functionality can only be reached by entering a url such as:

http://admin-beta.development.performance.service.gov.uk/dashboards/5d2b23cd-8497-4264-9595-f101f7251f5c

There is another story being worked on to allow the hub page to be accessed from the dashboard list - see https://www.pivotaltracker.com/story/show/89863010