### PR TITLE
Enable download of digital take-up spreadsheet template

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -36,6 +36,7 @@ import application.controllers.authentication
 import application.controllers.admin.dashboards
 import application.controllers.registrations
 import application.controllers.dashboards
+import application.controllers.digital_take_up
 import application.controllers.admin.transforms
 import application.controllers.upload
 import application.controllers.dashboards

--- a/application/assets/scss/performanceplatform-admin/style.scss
+++ b/application/assets/scss/performanceplatform-admin/style.scss
@@ -69,6 +69,10 @@ textarea.json-field {
   color: $gray-light;
 }
 
+fieldset {
+  font-weight: bold;
+}
+
 .form-group p.hint {
   margin-bottom: 0;
 }
@@ -80,6 +84,71 @@ textarea.json-field {
   @media (min-width: 992px) {
     float: right;
     margin-top: 5px;
+  }
+}
+
+#dashboard-hub {
+  > section > header h1 {
+    font-size: 24px;
+  }
+}
+
+.dashboard-data-item {
+  margin-top: 30px;
+  padding-top: 10px;
+  border-top: 1px solid $gray-light;
+
+  h1 {
+    font-size: 18px;
+  }
+
+  ul {
+    padding: 0;
+    list-style: disc;
+  }
+
+  li {
+    margin-left: 16px;
+  }
+}
+
+header.form {
+  margin-bottom: 20px;
+
+  h1 {
+    margin-bottom: 20px;
+  }
+
+  small {
+    display: block;
+  }
+}
+
+ul.checkbox-set {
+  padding: 0;
+  list-style: none;
+
+  li {
+    float: left;
+    clear: left;
+    label {
+      font-weight: normal;
+    }
+  }
+}
+
+.choice {
+  padding: 10px;
+  margin-bottom: 10px;
+  border: 2px solid #DCDEDD;
+  background-color: #F2F4F3;
+
+  label {
+    margin-left: 8px;
+  }
+
+  p {
+    margin-left: 24px;
   }
 }
 

--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -26,6 +26,9 @@ DASHBOARD_ROUTE = '/dashboards'
 @requires_permission('dashboard')
 def dashboard_hub(admin_client, uuid):
     template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
     dashboard_dict = admin_client.get_dashboard(uuid)
     Dashboard = namedtuple('Dashboard', dashboard_dict.keys())
     dashboard = Dashboard(**dashboard_dict)

--- a/application/controllers/digital_take_up.py
+++ b/application/controllers/digital_take_up.py
@@ -1,0 +1,136 @@
+from application import app
+from application.forms import UploadOptionsForm, ChannelOptionsForm
+from flask import (
+    session,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    request,
+    make_response
+)
+from application.helpers import (
+    base_template_context,
+    requires_authentication,
+    requires_permission,
+    to_error_list
+)
+from application.utils.datetimeutil import (
+    a_week_ago,
+    a_month_ago,
+    start_of_week,
+    start_of_month,
+    to_datetime
+)
+
+DASHBOARD_ROUTE = '/dashboard'
+
+
+@app.route(
+    '{0}/<uuid>/digital-take-up/upload-options'.format(DASHBOARD_ROUTE),
+    methods=['GET', 'POST'])
+@requires_authentication
+@requires_permission('dashboard')
+def upload_options(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+    form = UploadOptionsForm()
+    if form.validate_on_submit():
+        session['upload_choice'] = form.data['upload_option']
+        if session['upload_choice'] != 'api':
+            return redirect(url_for('channel_options', uuid=uuid))
+        else:
+            return redirect(url_for('api_get_in_touch', uuid=uuid))
+    if form.errors:
+        flash(to_error_list(form.errors), 'danger')
+    return render_template(
+        'digital_take_up/upload-options.html',
+        uuid=uuid,
+        upload_options=[option for option in form.upload_option],
+        form=form,
+        **template_context)
+
+
+@app.route(
+    '{0}/<uuid>/digital-take-up/api-get-in-touch'.format(DASHBOARD_ROUTE))
+@requires_authentication
+@requires_permission('dashboard')
+def api_get_in_touch(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user']
+    })
+    return render_template(
+        'digital_take_up/api-get-in-touch.html',
+        email=app.config['NOTIFICATIONS_EMAIL'],
+        uuid=uuid,
+        **template_context)
+
+
+@app.route(
+    '{0}/<uuid>/digital-take-up/channel-options'.format(DASHBOARD_ROUTE),
+    methods=['GET', 'POST'])
+@requires_authentication
+@requires_permission('dashboard')
+def channel_options(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+    form = ChannelOptionsForm()
+    if request.method == 'POST':
+        if True in form.data.values():
+            session['channel_choices'] = [
+                key for key, val in form.data.items() if val]
+            return redirect(url_for('download', uuid=uuid))
+        else:
+            error = 'Please select one or more channel options.'
+            flash(error, 'danger')
+    return render_template(
+        'digital_take_up/channel-options.html',
+        uuid=uuid,
+        form=form,
+        **template_context)
+
+
+@app.route('{0}/<uuid>/digital-take-up/download'.format(DASHBOARD_ROUTE))
+@requires_authentication
+@requires_permission('dashboard')
+def download(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+    return render_template(
+        'digital_take_up/download.html',
+        uuid=uuid,
+        **template_context)
+
+
+@app.route(
+    '{0}/<uuid>/digital-take-up/spreadsheet-template'.format(DASHBOARD_ROUTE))
+@requires_authentication
+@requires_permission('dashboard')
+def spreadsheet_template(admin_client, uuid):
+    csv = make_csv()
+    response = make_response(csv)
+    response.headers[
+        "Content-Disposition"] = "attachment; filename=digital_take_up.csv"
+    return response
+
+
+def make_csv():
+    csv = "_timestamp,period,channel,count\n"
+    if session['upload_choice'] == 'week':
+        start_date = start_of_week(a_week_ago())
+    else:
+        start_date = start_of_month(a_month_ago())
+    timestamp = to_datetime(start_date).isoformat()
+    for channel in session['channel_choices']:
+        csv += '{0},{1},{2},0\n'.format(
+            timestamp,
+            session['upload_choice'],
+            channel)
+    return csv

--- a/application/forms.py
+++ b/application/forms.py
@@ -2,7 +2,7 @@ from application import app
 from application.fields.json_textarea import JSONTextAreaField
 from flask_wtf import Form as FlaskWTFForm
 from wtforms import (FieldList, Form, FormField, TextAreaField, TextField,
-                     HiddenField)
+                     RadioField, BooleanField, HiddenField)
 from wtforms.validators import Required, Email, URL, Optional
 from wtforms_components.fields.select import SelectField
 import requests
@@ -244,3 +244,24 @@ class DashboardHubForm(FlaskWTFForm):
     description = TextAreaField(
         'Dashboard description',
         validators=[Required(message='Description cannot be blank')])
+
+
+class UploadOptionsForm(FlaskWTFForm):
+    upload_option = RadioField(
+        '',
+        choices=[
+            ('api', "Automatically upload from your transaction's API"),
+            ('week', 'Manually upload a spreadsheet every week'),
+            ('month', 'Manually upload a spreadsheet every month')
+        ],
+        default='week',
+        validators=[Required(message='Please select an upload option')])
+
+
+class ChannelOptionsForm(FlaskWTFForm):
+    website = BooleanField('Website')
+    api = BooleanField('Api')
+    telephone_human = BooleanField('Telephone (human operator)')
+    telephone_automated = BooleanField('Telephone (automated)')
+    paper_form = BooleanField('Paper form')
+    face_to_face = BooleanField('Face to face')

--- a/application/templates/dashboards/dashboard-hub.html
+++ b/application/templates/dashboards/dashboard-hub.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 
-<section>
+<section id="dashboard-hub">
   <header class="keyline-separator">
     <span class="hint">Your dashboard</span>
     <h1>{{ dashboard_title }}</h1>
@@ -50,8 +50,27 @@
       <h1>Dashboard data</h1>
     </header>
 
-    <ul>
-    </ul>
+    <section class="dashboard-data-item">
+      <div class="row">
+        <header class="col-md-3">
+          <h1>Digital take-up</h1>
+        </header>
+
+
+        <div class="col-md-5">
+          <p>
+            To calculate your digital take-up you will need:
+          </p>
+
+          <ul>
+            <li>data for how many people complete the transaction using the digital service</li>
+          </ul>
+
+          <p><a href="https://www.gov.uk/service-manual/communications/increasing-digital-takeup.html">Find out more about digital take-up</a></p>
+          <p><a href="{{ url_for('upload_options', uuid=uuid) }}" class="btn btn-info">Add digital take-up</a></p>
+        </div>
+      </div>
+    </section>
   </section>
 
   <footer>

--- a/application/templates/digital_take_up/api-get-in-touch.html
+++ b/application/templates/digital_take_up/api-get-in-touch.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<div class="row">
+  <div class="col-sm-8 col-md-6">
+    <div class="confirmation-box">
+      <h1 class="h3">
+        <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+        Request API access
+      </h1>
+      <p>
+        Please email
+        {{ email }}
+      </p>
+    </div>
+  </div>
+</div>
+
+<h2 class="h4">What happens next</h2>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    One of our developers will respond to your email
+    and work with you to make your transaction report
+    data automatically via our API.
+  </p>
+</div>
+
+<a href="{{ url_for('dashboard_hub', uuid=uuid) }}">Back to dashboard</a>
+
+{% endblock %}

--- a/application/templates/digital_take_up/channel-options.html
+++ b/application/templates/digital_take_up/channel-options.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<section>
+  <header class='form'>
+    <span class="hint">Add digital take-up</span>
+    <div class="row">
+      <h1 class="col-md-6">How can people use your transaction?</h1>
+    </div>
+    <p class="small">
+      Select all the ways people can complete this transaction.
+    </p>
+    <div class="row">
+      <p class="col-md-4 small">
+        Only include contact methods where users can actually complete
+        the transaction. For example, don't include Telephone if the
+        operator will just tell you to go and fill in a form.
+      </p>
+    </div>
+  </header>
+
+  <form method="POST" action="{{ url_for('channel_options', uuid=uuid) }}" role="form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    <fieldset class="form-group">Digital channels
+      <ul class="checkbox-set">
+        <li class="choice">
+          {{ form.website }}
+          {{ form.website.label}}
+        </li>
+        <li class="choice">
+          {{ form.api }}
+          {{ form.api.label}}
+        </li>
+      </ul>
+    </fieldset>
+
+    <fieldset class="form-group">Non-digital channels
+      <ul class="checkbox-set">
+        <li class="choice">
+          {{ form.telephone_human }}
+          {{ form.telephone_human.label}}
+        </li>
+        <li class="choice">
+          {{ form.telephone_automated }}
+          {{ form.telephone_automated.label}}
+        </li>
+        <li class="choice">
+          {{ form.paper_form }}
+          {{ form.paper_form.label }}
+        </li>
+        <li class="choice">
+          {{ form.face_to_face }}
+          {{ form.face_to_face.label }}
+        </li>
+      </ul>
+    </fieldset>
+
+    <input type="submit" class="btn btn-success" value="Continue" name="submit-channel-options">
+  </form>
+</section>
+
+{% endblock %}

--- a/application/templates/digital_take_up/download.html
+++ b/application/templates/digital_take_up/download.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<section>
+  <header class='form'>
+    <span class="hint">Add digital take-up</span>
+    <h1>Download spreadsheet template</h1>
+    <div class="row">
+      <p class="col-md-4 small">
+        Click the button below to download a CSV file that you can
+        import into your preferred spreadsheet software.
+      </p>
+    </div>
+    <div class="row">
+      <p class="col-md-4 small">
+        Add data to the imported spreadsheet and when you're ready,
+        click the Add digital take-up button on your dashboard's
+        edit page to upload your data.
+      </p>
+    </div>
+  </header>
+
+  <p class="hint">
+    <a href="{{ url_for('spreadsheet_template', uuid=uuid) }}" class="btn btn-success btn">Download template</a>
+    CSV file
+  </p>
+  <a href="{{ url_for('dashboard_hub', uuid=uuid) }}">Back to dashboard</a>
+</section>
+
+{% endblock %}

--- a/application/templates/digital_take_up/upload-options.html
+++ b/application/templates/digital_take_up/upload-options.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<section>
+  <header class="form">
+    <span class="hint">Add digital take-up</span>
+    <div class="row">
+      <h1 class="col-md-6">How would you like to upload your data?</h1>
+    </div>
+    <p class="small">
+      Your data can be uploaded to the dashboard in a number of different ways.<br>
+      Select which option would work best for your service.
+    </p>
+  </header>
+
+  <form method="POST" action="{{ url_for('upload_options', uuid=uuid) }}" role="form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    <div class="row">
+      <div class="form-group col-md-5">
+        <div class="choice">
+          {{ upload_options[0] }}
+          {{ upload_options[0].label}}
+          <p class="hint">
+            We'll work with your developers to make your<br>
+            transaction report data automatically via an API.
+          </p>
+
+          <p class="hint">
+            You'll only have to do this once.
+          </p>
+        </div>
+
+        <div class="choice">
+          {{ upload_options[1] }}
+          {{ upload_options[1].label}}
+          <p class="hint">
+            We'll create a template spreadsheet for you to fill in.<br>
+            Take a look at a sample template.
+          </p>
+
+          <p class="hint">
+            You'll have to upload the data every week.
+          </p>
+        </div>
+
+        <div class="choice">
+          {{ upload_options[2] }}
+          {{ upload_options[2].label}}
+          <p class="hint">
+            We'll create a template spreadsheet for you to fill in.<br>
+            Take a look at a sample template.
+          </p>
+
+          <p class="hint">
+            You'll have to upload the data every month.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <input type="submit" class="btn btn-success" value="Continue" name="submit-upload-options">
+  </form>
+</section>
+
+{% endblock %}

--- a/application/utils/datetimeutil.py
+++ b/application/utils/datetimeutil.py
@@ -1,0 +1,23 @@
+from datetime import datetime, time, timedelta, date
+from dateutil.relativedelta import relativedelta
+import pytz
+
+
+def to_datetime(a_date):
+    return datetime.combine(a_date, time(0)).replace(tzinfo=pytz.UTC)
+
+
+def a_week_ago():
+    return date.today() - timedelta(days=7)
+
+
+def start_of_month(date):
+    return date.replace(day=1)
+
+
+def a_month_ago():
+    return date.today() + relativedelta(months=-1)
+
+
+def start_of_week(date):
+    return date - timedelta(days=date.weekday())

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ requests-oauthlib==0.4.1
 pyScss==1.2.0
 xlrd==0.9.3
 boto==2.36.0
+python-dateutil

--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -7,3 +7,4 @@ nose==1.3.3
 pep8==1.5.7
 PyHamcrest==1.8.0
 autopep8==1.0.4
+freezegun==0.1.18

--- a/tests/application/controllers/test_dashboards.py
+++ b/tests/application/controllers/test_dashboards.py
@@ -106,6 +106,21 @@ class DashboardHubPageTestCase(FlaskAppTestCase):
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
            return_value=dashboard_data())
+    def test_renders_a_section_for_digital_take_up(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.data, contains_string('<h1>Digital take-up</h1>'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_renders_a_link_to_add_digital_take_up(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
+        url = '/dashboard-uuid/digital-take-up/upload-options'
+        assert_that(response.data, contains_string(url))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
     @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
     def test_dashboard_is_updated(
             self, mock_update_dashboard, mock_get_dashboard):

--- a/tests/application/controllers/test_digital_take_up.py
+++ b/tests/application/controllers/test_digital_take_up.py
@@ -1,0 +1,216 @@
+from tests.application.support.flask_app_test_case import FlaskAppTestCase
+from application import app
+from freezegun import freeze_time
+from hamcrest import (
+    assert_that,
+    equal_to,
+    contains_string,
+    ends_with
+)
+
+
+class UploadOptionsPageTestCase(FlaskAppTestCase):
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'upload_option': 'week'
+        }
+        params.update(options)
+        return params
+
+    def setUp(self):
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'dashboard']
+            }
+
+    def test_authenticated_user_is_required(self):
+        with self.client.session_transaction() as session:
+            del session['oauth_token']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_authorised_user_is_required(self):
+        with self.client.session_transaction() as session:
+            session['oauth_user'] = {'permissions': ['signin']}
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_upload_options_slug_renders_upload_options_page(self):
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options')
+        assert_that(response.status, equal_to('200 OK'))
+
+    def test_upload_option_field_is_required(self):
+        data = self.params({'upload_option': ''})
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options',
+            data=data)
+        assert_that(response.data, contains_string(
+            'select an upload option'))
+
+    def test_stores_chosen_option_in_the_session(self):
+        self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options',
+            data=self.params())
+        self.assert_session_contains('upload_choice', 'week')
+
+    def test_redirects_to_channel_options_page(self):
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options',
+            data=self.params())
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/channel-options'))
+
+    def test_api_choice_redirects_to_api_get_in_touch_page(self):
+        data = self.params({'upload_option': 'api'})
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/upload-options',
+            data=data)
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/api-get-in-touch'))
+
+
+class ChannelOptionsPageTestCase(FlaskAppTestCase):
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'website': 'y',
+            'telephone_human': 'y'
+        }
+        params.update(options)
+        return params
+
+    def setUp(self):
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'dashboard']
+            }
+
+    def test_authenticated_user_is_required(self):
+        with self.client.session_transaction() as session:
+            del session['oauth_token']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_authorised_user_is_required(self):
+        with self.client.session_transaction() as session:
+            session['oauth_user'] = {'permissions': ['signin']}
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_channel_options_slug_renders_channel_choices_page(self):
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options')
+        assert_that(response.status, equal_to('200 OK'))
+
+    def test_one_or_more_channel_options_are_required(self):
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options',
+            data={})
+        assert_that(response.data, contains_string(
+            'select one or more channel options'))
+
+    def test_stores_chosen_channel_options_in_the_session(self):
+        self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options',
+            data=self.params())
+        self.assert_session_contains(
+            'channel_choices', ['website', 'telephone_human'])
+
+    def test_redirects_to_download_template_page(self):
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/digital-take-up/channel-options',
+            data=self.params())
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/download'))
+
+
+class DownloadTemplatePageTestCase(FlaskAppTestCase):
+
+    def setUp(self):
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'dashboard']
+            }
+
+    def test_authenticated_user_is_required(self):
+        with self.client.session_transaction() as session:
+            del session['oauth_token']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/download')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_authorised_user_is_required(self):
+        with self.client.session_transaction() as session:
+            session['oauth_user'] = {'permissions': ['signin']}
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/download')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_download_slug_renders_download_template_page(self):
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/download')
+        assert_that(response.status, equal_to('200 OK'))
+
+    def test_download_page_contains_a_download_link(self):
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/download')
+        url = '/dashboard-uuid/digital-take-up/spreadsheet-template'
+        assert_that(response.data, contains_string(url))
+
+    def test_spreadsheet_template_slug_responds_with_a_csv_file(self):
+        with self.client.session_transaction() as session:
+            session['upload_choice'] = 'week'
+            session['channel_choices'] = ['api', 'face_to_face']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/spreadsheet-template')
+        assert_that(response.headers[2][1], contains_string('attachment'))
+        assert_that(response.headers[2][1],
+                    contains_string('filename=digital_take_up.csv'))
+
+    @freeze_time("2015-03-26")
+    def test_serves_a_weekly_csv_file_for_chosen_channels(self):
+        with self.client.session_transaction() as session:
+            session['upload_choice'] = 'week'
+            session['channel_choices'] = ['api', 'face_to_face']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/spreadsheet-template')
+        expected_content = (
+            "_timestamp,period,channel,count\n"
+            "2015-03-16T00:00:00+00:00,week,api,0\n"
+            "2015-03-16T00:00:00+00:00,week,face_to_face,0\n"
+        )
+        assert_that(response.data, equal_to(expected_content))
+
+    @freeze_time("2015-03-26")
+    def test_serves_a_monthly_csv_file_for_chosen_channels(self):
+        with self.client.session_transaction() as session:
+            session['upload_choice'] = 'month'
+            session['channel_choices'] = ['api', 'face_to_face']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/digital-take-up/spreadsheet-template')
+        expected_content = (
+            "_timestamp,period,channel,count\n"
+            "2015-02-01T00:00:00+00:00,month,api,0\n"
+            "2015-02-01T00:00:00+00:00,month,face_to_face,0\n"
+        )
+        assert_that(response.data, equal_to(expected_content))


### PR DESCRIPTION
Adds a digital take-up section to the dashboard hug page of the admin app V2 containing an 'Add digital take-up' button. When clicked, the user is taken through a flow where they can choose how they want to upload digital take-up data and for which channels. If they wish to upload data weekly or monthly rather than via an API, they are presented with a spreadsheet template (CSV file) for download that is personalised to their requirements.

See https://www.pivotaltracker.com/story/show/89863074 for more information and the Marvel App designs.
