### PR TITLE
Add missing SES credentials

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -13,6 +13,7 @@ app = Flask(__name__)
 GOVUK_ENV = getenv('GOVUK_ENV', 'development')
 
 app.config['LOG_LEVEL'] = "INFO"
+app.config.from_object('application.config.default')
 app.config.from_object('application.config.{0}'.format(GOVUK_ENV))
 app.secret_key = app.config['COOKIE_SECRET_KEY']
 app.redis_instance = Redis(

--- a/application/config/default.py
+++ b/application/config/default.py
@@ -1,0 +1,2 @@
+NOTIFICATIONS_EMAIL = 'notifications@performance.service.gov.uk'
+NO_REPLY_EMAIL = 'no-reply@performance.service.gov.uk'

--- a/application/config/development.py
+++ b/application/config/development.py
@@ -31,8 +31,6 @@ FAKE_OAUTH_USER = {
 
 AWS_ACCESS_KEY_ID = 'AWS access key id'
 AWS_SECRET_ACCESS_KEY = 'AWS secret access key'
-NOTIFICATIONS_EMAIL = 'notifications@performance.service.gov.uk'
-NO_REPLY_EMAIL = 'no-reply@performance.service.gov.uk'
 
 # You can use development_local_overrides.py in this directory to set config
 # that is unique to your development environment, like OAuth IDs and secrets.


### PR DESCRIPTION
These do not change per environment and are not secret, so add a new
config file default and move the settings there to save duplicating in
multiple places in pp-deployment