### PR TITLE
Prefill the visualisation field on module type select

### DIFF
--- a/application/static/javascripts/edit_dashboard.js
+++ b/application/static/javascripts/edit_dashboard.js
@@ -4,13 +4,16 @@
     $('.js-module-type-selector').on('change', function () {
       var type = $(this).find('[value="' + $(this).val() + '"]').text(),
         $queryParams = $(this).closest('.module').find('.js-query-parameters');
+        $visualisationParams = $(this).closest('.module').find('.js-visualisation-parameters');
 
       $.getJSON('/static/json/' + type + '.json')
         .done(function (data) {
-          $queryParams.val(JSON.stringify(data, null, '\t'));
+          $queryParams.val(JSON.stringify(data['query'], null, '\t'));
+          $visualisationParams.val(JSON.stringify(data['visualisation'], null, '\t'));
         })
         .fail(function() {
           $queryParams.val('{}');
+          $visualisationParams.val('{}');
         });
     });
   }

--- a/application/static/json/applications.json
+++ b/application/static/json/applications.json
@@ -1,1 +1,24 @@
-{}
+{
+  "query": {},
+  "visualisation": {  
+    "pin-to":"handling_time",
+    "max-bars":22,
+    "value-attribute":"count:sum",
+    "axes":{  
+      "y":[  
+        {  
+          "format":"integer",
+          "key":"count:sum",
+          "label":"Number of civil applications"
+        }
+      ],
+      "x":{  
+        "format":"string",
+        "key":"title",
+        "label":""
+      }
+    },
+    "target":20
+  }
+}
+

--- a/application/static/json/bar_chart_with_number.json
+++ b/application/static/json/bar_chart_with_number.json
@@ -1,1 +1,17 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "axes": {
+        "y": [
+            {
+                "label": "Percentage digital take-up"
+            }
+        ]
+    }, 
+    "axis-period": "quarter", 
+    "format": {
+        "type": "percent"
+    }, 
+    "value-attribute": "digital_takeup"
+  }
+}

--- a/application/static/json/column.json
+++ b/application/static/json/column.json
@@ -1,1 +1,11 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "axis-period": "quarter", 
+    "format": {
+        "sigfigs": 3, 
+        "type": "percent"
+    }, 
+    "value-attribute": "count"
+  }
+}

--- a/application/static/json/completion_rate.json
+++ b/application/static/json/completion_rate.json
@@ -1,10 +1,36 @@
 {
-  "duration": 52,
-  "collect": [
-    "count:sum"
-  ],
-  "group_by": [
-    "channel"
-  ],
-  "period": "week"
+  "query": {
+    "duration": 52,
+    "collect": [
+      "count:sum"
+    ],
+    "group_by": [
+      "channel"
+    ],
+    "period": "week"
+  },
+  "visualisation" : {
+    "axes": {
+        "x": {
+            "format": "date", 
+            "key": [
+                "_start_at", 
+                "_end_at"
+            ], 
+            "label": "Date"
+        }, 
+        "y": [
+            {
+                "format": "percent", 
+                "key": "completion", 
+                "label": "Digital take-up"
+            }
+        ]
+    }, 
+    "axis-period": "month", 
+    "denominator-matcher": ".+", 
+    "matching-attribute": "channel", 
+    "numerator-matcher": "(Digital)", 
+    "value-attribute": "count:sum"
+  }
 }

--- a/application/static/json/completion_table.json
+++ b/application/static/json/completion_table.json
@@ -1,1 +1,26 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "category":"borrower_category",
+    "value-attribute":"count:sum",
+    "matching-attribute":"channel",
+    "axes":{  
+      "y":[  
+        {  
+          "label":"Digital take-up",
+          "key":"completion",
+          "format":"percent"
+        }
+      ],
+      "x":{  
+        "label":"User demographic",
+        "key":"borrower_category",
+        "format":"sentence"
+      }
+    },
+    "numerator-matcher":"^online$",
+    "denominator-matcher":"^(.)*$",
+    "sort-by":"completion",
+    "sort-order":"ascending"
+  }
+}

--- a/application/static/json/grouped_timeseries.json
+++ b/application/static/json/grouped_timeseries.json
@@ -1,10 +1,50 @@
 {
-  "duration": 52,
-  "collect": [
-    "count:sum"
-  ],
-  "group_by": [
-    "channel"
-  ],
-  "period": "week"
+  "query": {
+    "duration": 52,
+    "collect": [
+      "count:sum"
+    ],
+    "group_by": [
+      "channel"
+    ],
+    "period": "week"
+  },
+  "visualisation" : {
+    "axes": {
+        "x": {
+            "format": {
+                "format": "D MMM YYYY", 
+                "type": "date"
+            }, 
+            "key": [
+                "_start_at", 
+                "_end_at"
+            ], 
+            "label": "Date"
+        }, 
+        "y": [
+            {
+                "format": "percent", 
+                "groupId": "desktop", 
+                "label": "Desktop"
+            }, 
+            {
+                "format": "percent", 
+                "groupId": "mobile", 
+                "label": "Mobile"
+            }, 
+            {
+                "format": "percent", 
+                "groupId": "tablet", 
+                "label": "Tablet"
+            }
+        ]
+    }, 
+    "axis-period": "month", 
+    "category": "deviceCategory", 
+    "one-hundred-percent": true, 
+    "show-line-labels": true, 
+    "use_stack": false, 
+    "value-attribute": "visitors:sum"
+  }
 }

--- a/application/static/json/headline_figure.json
+++ b/application/static/json/headline_figure.json
@@ -1,1 +1,23 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "axes": {
+        "x": {
+            "format": "string", 
+            "key": "metric", 
+            "label": "Applications recieved"
+        }, 
+        "y": [
+            {
+                "format": "integer", 
+                "key": "value:sum", 
+                "label": "Number of applications"
+            }
+        ]
+    }, 
+    "classes": "cols3", 
+    "pin-to": "metric", 
+    "target": "applications_recieved", 
+    "value-attribute": "value:sum"
+  }
+}

--- a/application/static/json/journey.json
+++ b/application/static/json/journey.json
@@ -1,1 +1,24 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "axes": {
+        "y": [
+            {
+                "format": "integer", 
+                "groupId": "pay-foreign-marriage-certificates:start", 
+                "label": "Start"
+            }, 
+            {
+                "format": "integer", 
+                "groupId": "pay-foreign-marriage-certificates:confirm", 
+                "label": "Confirm"
+            }, 
+            {
+                "format": "integer", 
+                "groupId": "pay-foreign-marriage-certificates:done", 
+                "label": "Done"
+            }
+        ]
+    }
+  }
+}

--- a/application/static/json/kpi.json
+++ b/application/static/json/kpi.json
@@ -1,7 +1,18 @@
-{
-  "sort_by": "_timestamp:descending",
-  "filter_by": [
-    "service_id:<service-id>",
-    "type:seasonally-adjusted"
-  ]
+{  
+  "query": {
+    "sort_by": "_timestamp:descending",
+    "filter_by": [
+      "service_id:<service-id>",
+      "type:seasonally-adjusted"
+    ]
+  },
+  "visualisation" : {
+    "classes": "cols3", 
+    "format": {
+        "magnitude": true, 
+        "sigfigs": 3, 
+        "type": "number"
+    }, 
+    "value-attribute": "number_of_transactions"
+  }
 }

--- a/application/static/json/list.json
+++ b/application/static/json/list.json
@@ -1,1 +1,11 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+      "classes": [
+          "cols2"
+      ], 
+      "label-attr": "pageTitle", 
+      "label-regex": "^(.*)\\s-[^-]+$", 
+      "link-attr": "pagePath"
+  }
+}

--- a/application/static/json/realtime.json
+++ b/application/static/json/realtime.json
@@ -1,4 +1,8 @@
-{
-  "limit": 722,
-  "sort_by": "_timestamp:descending"
+{  
+  "query": {
+    "limit": 722,
+    "sort_by": "_timestamp:descending"
+  },
+  "visualisation" : {
+  }
 }

--- a/application/static/json/section.json
+++ b/application/static/json/section.json
@@ -1,1 +1,4 @@
-{}
+{
+  "query": {},
+  "visualisation": {}
+}

--- a/application/static/json/single_timeseries.json
+++ b/application/static/json/single_timeseries.json
@@ -1,13 +1,38 @@
-{
-  "duration": 52,
-  "collect": [
-    "avgSessionDuration:sum"
-  ],
-  "group_by": [
-    "stage"
-  ],
-  "period": "week",
-  "filter_by": [
-    "stage:thank-you"
-  ]
+{  
+  "query": {
+    "duration": 52,
+    "collect": [
+      "avgSessionDuration:sum"
+    ],
+    "group_by": [
+      "stage"
+    ],
+    "period": "week",
+    "filter_by": [
+      "stage:thank-you"
+    ]
+  },
+  "visualisation" : {
+    "axes": {
+        "x": {
+            "format": "date", 
+            "key": [
+                "_start_at", 
+                "_end_at"
+            ], 
+            "label": "Date"
+        }, 
+        "y": [
+            {
+                "format": "integer", 
+                "label": "Completed applications"
+            }
+        ]
+    }, 
+    "category": "stage", 
+    "show-line-labels": true, 
+    "show-total-lines": true, 
+    "use_stack": false, 
+    "value-attribute": "count:sum"
+  }
 }

--- a/application/static/json/tab.json
+++ b/application/static/json/tab.json
@@ -1,1 +1,47 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "tabs": [
+        {
+            "axes": {
+                "x": {
+                    "format": "date", 
+                    "key": "_timestamp", 
+                    "label": "Date"
+                }
+            }, 
+            "data-source": {
+                "data-group": "govuk", 
+                "data-type": "monitoring", 
+                "query-params": {
+                    "period": "day"
+                }
+            }, 
+            "description": "", 
+            "module-type": "availability", 
+            "slug": "30-days", 
+            "title": "30 days"
+        }, 
+        {
+            "axes": {
+                "x": {
+                    "format": "time", 
+                    "key": "_timestamp", 
+                    "label": "Time"
+                }
+            }, 
+            "data-source": {
+                "data-group": "govuk", 
+                "data-type": "monitoring", 
+                "query-params": {
+                    "period": "hour"
+                }
+            }, 
+            "description": "", 
+            "module-type": "availability", 
+            "slug": "24-hours", 
+            "title": "24 hours"
+        }
+    ]
+  }
+}

--- a/application/static/json/table.json
+++ b/application/static/json/table.json
@@ -1,3 +1,23 @@
 {
-  "start_at": "2015-01-01T00:00:00Z"
+  "query": {
+    "start_at": "2015-01-01T00:00:00Z"
+  },
+  "visualisation" : {
+    "axes": {
+        "x": {
+            "format": "url", 
+            "key": "url", 
+            "label": "URL"
+        }, 
+        "y": [
+            {
+                "format": "integer", 
+                "key": "comment_count:sum", 
+                "label": "Total comments"
+            }
+        ]
+    }, 
+    "sort-by": "comment_count:sum", 
+    "sort-order": "descending"
+  }
 }

--- a/application/static/json/user_satisfaction.json
+++ b/application/static/json/user_satisfaction.json
@@ -1,3 +1,8 @@
 {
-  "sort_by": "_timestamp:ascending"
+  "query": {
+    "sort_by": "_timestamp:ascending"
+  },
+  "visualisation" : {
+    "value-attribute": "123"
+  }
 }

--- a/application/static/json/user_satisfaction_graph.json
+++ b/application/static/json/user_satisfaction_graph.json
@@ -1,1 +1,49 @@
-{}
+{
+  "query": {},
+  "visualisation": {
+    "axes": {
+        "x": {
+            "format": "date", 
+            "key": "_start_at", 
+            "label": "Date"
+        }, 
+        "y": [
+            {
+                "format": "percent", 
+                "key": "score", 
+                "label": "User satisfaction"
+            }, 
+            {
+                "format": "integer", 
+                "key": "rating_1", 
+                "label": "Very dissatisfied"
+            }, 
+            {
+                "format": "integer", 
+                "key": "rating_2", 
+                "label": "Dissatisfied"
+            }, 
+            {
+                "format": "integer", 
+                "key": "rating_3", 
+                "label": "Neither satisfied or dissatisfied"
+            }, 
+            {
+                "format": "integer", 
+                "key": "rating_4", 
+                "label": "Satisfied"
+            }, 
+            {
+                "format": "integer", 
+                "key": "rating_5", 
+                "label": "Very satisfied"
+            }
+        ]
+    }, 
+    "axis-period": "month", 
+    "migrated": true, 
+    "total-attribute": "num_responses", 
+    "trim": false, 
+    "value-attribute": "score"
+  }
+}

--- a/application/templates/admin/dashboards/create.html
+++ b/application/templates/admin/dashboards/create.html
@@ -266,7 +266,7 @@
             <div class="form-group">
               {{ module.options.label(class='col-sm-2 control-label') }}
               <div class="col-sm-10">
-                {{ module.options(class='form-control json-field') }}
+                {{ module.options(class='form-control json-field js-visualisation-parameters') }}
                 <p class="help-block">Adjust how the visualisation looks. Settings must be <a href="http://jsonlint.com/" target="_blank">valid JSON</a></p>
               </div>
             </div>


### PR DESCRIPTION
user_satisfaction seems not to be used. It should be deleted?

@theotherurmy Could you check this out and see if it makes sense? As I thought it would be quicker I have added in visualisation config examples which do not necessarily come from the same source as the query options examples. As I haven't configured a module in a while I realise I don't know if this makes sense so could you take a look and see if this example json is acually useful?