### PR TITLE
Add user satisfaction section to dashboard hub

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -37,6 +37,7 @@ import application.controllers.authentication
 import application.controllers.admin.dashboards
 import application.controllers.registrations
 import application.controllers.dashboards
+import application.controllers.user_satisfaction
 import application.controllers.digital_take_up
 import application.controllers.admin.transforms
 import application.controllers.upload

--- a/application/controllers/user_satisfaction.py
+++ b/application/controllers/user_satisfaction.py
@@ -1,0 +1,130 @@
+from application import app
+from application.forms import DonePageURLForm
+from flask import (
+    session,
+    render_template,
+    redirect,
+    url_for,
+    flash
+)
+from application.helpers import (
+    base_template_context,
+    requires_authentication,
+    requires_permission,
+    to_error_list,
+    redirect_if_module_exists
+)
+import re
+
+DASHBOARD_ROUTE = '/dashboard'
+
+
+@app.route(
+    '{0}/<uuid>/user-satisfaction/add'.format(DASHBOARD_ROUTE),
+    methods=['GET', 'POST'])
+@requires_authentication
+@requires_permission('dashboard')
+@redirect_if_module_exists('user-satisfaction-score')
+def add_user_satisfaction(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+    form = DonePageURLForm()
+    if form.validate_on_submit():
+        url = form.data['done_page_url']
+        match = re.search('/done/([^/?]+)', url)
+        if match is None:
+            return redirect(url_for('get_in_touch', uuid=uuid))
+        data_group = match.group(1)
+        data_type = 'user-satisfaction-score'
+        data_set = admin_client.get_data_set(data_group, data_type)
+        if data_set is None:
+            return redirect(url_for('get_in_touch', uuid=uuid))
+        module_config = _module_config({
+            'data_group': data_group,
+            'data_type': data_type,
+            'type_id': _get_user_satisfaction_module_type(admin_client)['id']})
+        admin_client.add_module_to_dashboard(uuid, module_config)
+        return redirect(url_for('dashboard_hub', uuid=uuid))
+    if form.errors:
+        flash(to_error_list(form.errors), 'danger')
+    return render_template(
+        'user_satisfaction/add.html',
+        uuid=uuid,
+        form=form,
+        **template_context)
+
+
+@app.route(
+    '{0}/<uuid>/user-satisfaction/get-in-touch'.format(DASHBOARD_ROUTE))
+@requires_authentication
+@requires_permission('dashboard')
+def get_in_touch(admin_client, uuid):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user']
+    })
+    return render_template(
+        'user_satisfaction/get-in-touch.html',
+        email=app.config['NOTIFICATIONS_EMAIL'],
+        uuid=uuid,
+        **template_context)
+
+
+def _module_config(options={}):
+    module_config = {
+        'slug': 'user-satisfaction',
+        'title': 'User satisfaction',
+        'description':
+            'Average of scores rating satisfaction '
+            'from 100% (very satisfied) to 0% (very dissatisfied)',
+        'info': ['Data source: GOV.UK user feedback database',
+                 "<a href='/service-manual/measurement/user-satisfaction' "
+                 "rel='external'>User satisfaction</a> is measured by "
+                 'surveying users at the point of transaction completion. '
+                 'It is measured on a five-point scale, from most satisfied '
+                 'to least satisfied. The mean of these responses is '
+                 'converted to a percentage for display purposes.'],
+        'options': {
+            'axes': {
+                'x': {'format': 'date',
+                      'key': '_start_at',
+                      'label': 'Date'},
+                'y': [{'format': 'percent',
+                       'key': 'score',
+                       'label': 'User satisfaction'},
+                      {'format': 'integer',
+                       'key': 'rating_1',
+                       'label': 'Very dissatisfied'},
+                      {'format': 'integer',
+                       'key': 'rating_2',
+                       'label': 'Dissatisfied'},
+                      {'format': 'integer',
+                       'key': 'rating_3',
+                       'label': 'Neither satisified or dissatisfied'},
+                      {'format': 'integer',
+                       'key': 'rating_4',
+                       'label': 'Satisfied'},
+                      {'format': 'integer',
+                       'key': 'rating_5',
+                       'label': 'Very satisfied'}]
+            },
+            'axis-period': 'month',
+            'migrated': True,
+            'total-attribute': 'num_responses',
+            'trim': False,
+            'value-attribute': 'score'
+        },
+        'query_parameters': {'sort_by': '_timestamp:ascending'},
+        'order': 1
+    }
+    module_config.update(options)
+    return module_config
+
+
+def _get_user_satisfaction_module_type(admin_client):
+    module_types = admin_client.list_module_types()
+    for module_type in module_types:
+        if module_type['name'] == 'user_satisfaction_graph':
+            return module_type

--- a/application/forms.py
+++ b/application/forms.py
@@ -237,6 +237,15 @@ class AboutYourServiceForm(FlaskWTFForm):
         validators=[Required(message='Service description cannot be blank')])
 
 
+class DonePageURLForm(FlaskWTFForm):
+    done_page_url = TextField(
+        'Done page URL',
+        validators=[
+            URL(message='Done page URL format is invalid'),
+            Required(message='Done page URL cannot be blank')
+        ])
+
+
 class DashboardHubForm(FlaskWTFForm):
     title = TextField(
         'Dashboard title',

--- a/application/templates/dashboards/dashboard-hub.html
+++ b/application/templates/dashboards/dashboard-hub.html
@@ -53,6 +53,32 @@
     <section class="dashboard-data-item">
       <div class="row">
         <header class="col-md-3">
+          <h1>User satisfaction</h1>
+        </header>
+
+
+        {% if "user-satisfaction-score" in modules %}
+          <p class="advisory col-sm-12"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span>Data successfully set up</p>
+        {% else %}
+          <div class="col-md-5">
+            <p>
+              To calculate your user satisfaction you will need:
+            </p>
+
+            <ul>
+              <li>a feedback page on GOV.UK</li>
+            </ul>
+
+            <p><a href="https://www.gov.uk/service-manual/measurement/user-satisfaction.html">Find out more about feedback pages and user satisfaction</a></p>
+            <p><a href="{{ url_for('add_user_satisfaction', uuid=uuid) }}" class="btn btn-info">Add user satisfaction</a></p>
+          </div>
+        {% endif %}
+      </div>
+    </section>
+
+    <section class="dashboard-data-item">
+      <div class="row">
+        <header class="col-md-3">
           <h1>Digital take-up</h1>
         </header>
 

--- a/application/templates/user_satisfaction/add.html
+++ b/application/templates/user_satisfaction/add.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<section>
+  <header class="form">
+    <span class="hint">Add user satisfaction</span>
+    <div class="row">
+      <h1 class="col-md-6">Help us locate your data</h1>
+    </div>
+    <div class="row">
+      <p class="col-md-6 small">
+        To add user satisfaction data to your dashboard we require you to have a
+        done page with a user satisfaction survey. We use this to automatically
+        retrieve your user satisfaction data.
+      </p>
+    </div>
+  </header>
+
+  <form method="POST" action="{{ url_for('add_user_satisfaction', uuid=uuid) }}" role="form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    <div class="row">
+      <div class="form-group col-md-5">
+        {{ form.done_page_url.label }}
+        <p class="hint">eg https://www.gov.uk/done/apply-carers-allowance</p>
+        {{ form.done_page_url(class='form-control') }}
+      </div>
+    </div>
+
+    <input type="submit" class="btn btn-success" value="Submit done page URL" name="submit-done-page-url">
+  </form>
+</section>
+
+{% endblock %}

--- a/application/templates/user_satisfaction/get-in-touch.html
+++ b/application/templates/user_satisfaction/get-in-touch.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<div class="row">
+  <div class="col-sm-8 col-md-6">
+    <div class="confirmation-box">
+      <h1 class="h3">
+        <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+        Done page not found
+      </h1>
+      <p>
+        Please email
+        {{ email }}
+      </p>
+    </div>
+  </div>
+</div>
+
+<h2 class="h4">What happens next</h2>
+
+<div class="row">
+  <p class="col-sm-8 col-md-6">
+    One of our team will respond to your email
+    and work with you to configure your done page.
+  </p>
+</div>
+
+<a href="{{ url_for('dashboard_hub', uuid=uuid) }}">Back to dashboard</a>
+
+{% endblock %}

--- a/tests/application/controllers/test_dashboards.py
+++ b/tests/application/controllers/test_dashboards.py
@@ -131,6 +131,18 @@ class DashboardHubPageTestCase(FlaskAppTestCase):
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
            return_value=dashboard_data())
+    @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
+    def test_dashboard_is_updated(
+            self, mock_update_dashboard, mock_get_dashboard):
+        data = self.params()
+        self.client.post('/dashboards/dashboard-uuid', data=data)
+        post_json = mock_update_dashboard.call_args[0][1]
+        assert_that(
+            mock_update_dashboard.call_args[0][0], equal_to('dashboard-uuid'))
+        assert_that(post_json, has_entries(data))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
     def test_renders_a_section_for_digital_take_up(
             self, mock_get_dashboard):
         response = self.client.get('/dashboards/dashboard-uuid')
@@ -146,38 +158,34 @@ class DashboardHubPageTestCase(FlaskAppTestCase):
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")
     def test_advises_digital_take_up_has_been_added(self, mock_get_dashboard):
-
-        mock_get_dashboard.return_value = {
-            'id': 'dashboard-uuid',
-            'title': 'A dashboard',
-            'description': 'All about this dashboard',
-            'slug': 'valid-slug',
-            'owning_organisation': 'organisation-uuid',
-            'dashboard_type': 'transaction',
-            'customer_type': 'Business',
-            'strapline': 'Dashboard',
-            'business_model': 'Department budget',
-            'published': False,
-            'status': 'unpublished',
-            'modules': [{
-                'data_type': 'digital-takeup'
-            }]
-        }
-
+        mock_get_dashboard.return_value = dashboard_data(
+            {'modules': [{'data_type': 'user-satisfaction-score'}]})
         response = self.client.get('/dashboards/dashboard-uuid')
         assert_that(response.data, contains_string('Data successfully set up'))
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
            return_value=dashboard_data())
-    @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
-    def test_dashboard_is_updated(
-            self, mock_update_dashboard, mock_get_dashboard):
-        data = self.params()
-        self.client.post('/dashboards/dashboard-uuid', data=data)
-        post_json = mock_update_dashboard.call_args[0][1]
+    def test_renders_a_section_for_user_satisfaction(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
         assert_that(
-            mock_update_dashboard.call_args[0][0], equal_to('dashboard-uuid'))
-        assert_that(post_json, has_entries(data))
+            response.data, contains_string('<h1>User satisfaction</h1>'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value=dashboard_data())
+    def test_renders_a_link_to_add_user_satisfaction(
+            self, mock_get_dashboard):
+        response = self.client.get('/dashboards/dashboard-uuid')
+        url = '/dashboard-uuid/user-satisfaction/add'
+        assert_that(response.data, contains_string(url))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")
+    def test_advises_user_satisfaction_has_been_added(
+            self, mock_get_dashboard):
+        mock_get_dashboard.return_value = dashboard_data(
+            {'modules': [{'data_type': 'user-satisfaction-score'}]})
+        response = self.client.get('/dashboards/dashboard-uuid')
+        assert_that(response.data, contains_string('Data successfully set up'))
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
            return_value=dashboard_data())

--- a/tests/application/controllers/test_user_satisfaction.py
+++ b/tests/application/controllers/test_user_satisfaction.py
@@ -1,0 +1,177 @@
+from tests.application.support.flask_app_test_case import FlaskAppTestCase
+from application import app
+from hamcrest import (
+    assert_that,
+    equal_to,
+    contains_string,
+    ends_with,
+    has_entries,
+    match_equality
+)
+from mock import patch
+
+
+class AddUserSatisfactionTestCase(FlaskAppTestCase):
+
+    @staticmethod
+    def params(options={}):
+        params = {
+            'done_page_url': 'http://www.gov.uk/done/apply-some-transaction'}
+        params.update(options)
+        return params
+
+    def setUp(self):
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'dashboard']
+            }
+
+    def test_authenticated_user_is_required(self):
+        with self.client.session_transaction() as session:
+            del session['oauth_token']
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/user-satisfaction/add')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    def test_authorised_user_is_required(self):
+        with self.client.session_transaction() as session:
+            session['oauth_user'] = {'permissions': ['signin']}
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/user-satisfaction/add')
+        assert_that(response.status, equal_to('302 FOUND'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    def test_add_user_satisfaction_slug_renders_done_page_URL_form(
+            self, mock_get_dashboard):
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/user-satisfaction/add')
+        assert_that(response.status, equal_to('200 OK'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    def test_done_page_URL_field_is_required(self, mock_get_dashboard):
+        data = self.params({'done_page_url': ''})
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/user-satisfaction/add', data=data)
+        assert_that(response.data, contains_string(
+            'cannot be blank'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    def test_done_page_url_is_like_a_url(self, mock_get_dashboard):
+        data = self.params({'done_page_url': 'www.foo..com'})
+        response = self.client.post(
+            'dashboard/dashboard-uuid/user-satisfaction/add', data=data)
+        assert_that(response.status, equal_to('200 OK'))
+        assert_that(response.data,
+                    contains_string('Done page URL format is invalid'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    @patch("performanceplatform.client.admin.AdminAPI.get_data_set")
+    @patch("performanceplatform.client.admin.AdminAPI.add_module_to_dashboard")
+    @patch("performanceplatform.client.admin.AdminAPI.list_module_types")
+    def test_creates_a_module_if_a_user_satisfaction_data_set_exists(
+            self,
+            mock_list_module_types,
+            mock_add_module_to_dashboard,
+            mock_get_data_set,
+            mock_get_dashboard):
+        mock_get_data_set.return_value = {
+            'name': 'apply_some_transaction_user_satisfaction_score'}
+        mock_list_module_types.return_value = [{
+            'id': 'module-type-uuid',
+            'name': 'user_satisfaction_graph'}]
+        self.client.post(
+            '/dashboard/dashboard-uuid/user-satisfaction/add',
+            data=self.params())
+        mock_add_module_to_dashboard.assert_called_once_with(
+            'dashboard-uuid',
+            match_equality(has_entries({
+                'slug': 'user-satisfaction',
+                'data_group': 'apply-some-transaction',
+                'data_type': 'user-satisfaction-score',
+                'type_id': 'module-type-uuid'}))
+        )
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    @patch("performanceplatform.client.admin.AdminAPI.get_data_set")
+    @patch("performanceplatform.client.admin.AdminAPI.list_module_types")
+    @patch("performanceplatform.client.admin.AdminAPI.add_module_to_dashboard")
+    def test_redirects_to_dashboard_hub_page(
+            self,
+            mock_add_module_to_dashboard,
+            mock_list_module_types,
+            mock_get_data_set,
+            mock_get_dashboard):
+        mock_list_module_types.return_value = [{
+            'id': 'module-type-uuid',
+            'name': 'user_satisfaction_graph'}]
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/user-satisfaction/add',
+            data=self.params())
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('dashboards/dashboard-uuid'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    def test_renders_a_contact_us_page_if_unable_to_extract_done_page(
+            self, mock_get_dashboard):
+        params = self.params({
+            'done_page_url': 'http://www.gov.uk/some-transaction'})
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/user-satisfaction/add',
+            data=params)
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/get-in-touch'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
+           return_value={})
+    @patch("performanceplatform.client.admin.AdminAPI.get_data_set")
+    @patch("performanceplatform.client.admin.AdminAPI.list_module_types")
+    def test_renders_a_contact_us_page_if_no_user_satisfaction_data_set(
+            self,
+            mock_list_module_types,
+            mock_get_data_set,
+            mock_get_dashboard):
+        mock_get_data_set.return_value = None
+        response = self.client.post(
+            '/dashboard/dashboard-uuid/user-satisfaction/add',
+            data=self.params())
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/get-in-touch'))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")
+    def test_redirects_if_module_exists(self, mock_get_dashboard):
+
+        mock_get_dashboard.return_value = {
+            'id': 'dashboard-uuid',
+            'title': 'A dashboard',
+            'description': 'All about this dashboard',
+            'slug': 'valid-slug',
+            'owning_organisation': 'organisation-uuid',
+            'dashboard_type': 'transaction',
+            'customer_type': 'Business',
+            'strapline': 'Dashboard',
+            'business_model': 'Department budget',
+            'published': False,
+            'status': 'unpublished',
+            'modules': [{
+                'data_type': 'user-satisfaction-score'
+            }]
+        }
+
+        response = self.client.get(
+            '/dashboard/dashboard-uuid/user-satisfaction/add',
+            data=self.params())
+
+        assert_that(response.headers['Location'],
+                    ends_with('/dashboards/dashboard-uuid'))


### PR DESCRIPTION
Introduces a new section to the dashboard hub page, allowing service managers to set up their user satisfaction module.

The story with all tasks completed is available here:

https://www.pivotaltracker.com/n/projects/911872/stories/89863078