### PR TITLE
Enable clone dashboard

### DIFF
--- a/application/assets/scss/performanceplatform-admin/style.scss
+++ b/application/assets/scss/performanceplatform-admin/style.scss
@@ -258,3 +258,7 @@ ul.checkbox-set {
 .steps {
   padding-bottom: 10px;
 }
+
+select#dashboard-uuid {
+  max-width: 600px;
+}

--- a/application/assets/scss/performanceplatform-admin/style.scss
+++ b/application/assets/scss/performanceplatform-admin/style.scss
@@ -259,6 +259,13 @@ ul.checkbox-set {
   padding-bottom: 10px;
 }
 
-select#dashboard-uuid {
+span.bold {
+  font-weight: bold;
+}
+
+//Arguably this should be responsive but this is only an internal tool
+#dashboard-uuid {
   max-width: 600px;
 }
+
+

--- a/application/controllers/admin/dashboards.py
+++ b/application/controllers/admin/dashboards.py
@@ -191,8 +191,16 @@ def clone_module(admin_client, target_dashboard_uuid=None):
     if target_dashboard_uuid:
         target_dashboard_url = '/admin/dashboards/{}'.format(
             target_dashboard_uuid)
+        if 'pending_dashboard' not in session:
+            # Flash something here? This has happened
+            # because the user has got to the clone dashboard page
+            # via the url, not via the clone dashboard button.
+            # As a result there is no pending dashboard data.
+            return redirect(target_dashboard_url)
+        target_dashboard_name = session['pending_dashboard']['title']
     else:
         target_dashboard_url = '/admin/dashboards/new'
+        target_dashboard_name = 'new dashboard'
 
     template_context = base_template_context()
     template_context['user'] = session['oauth_user']
@@ -204,6 +212,7 @@ def clone_module(admin_client, target_dashboard_uuid=None):
                            source_dashboard_uuid=source_dashboard_uuid,
                            selected_dashboard=selected_dashboard,
                            target_dashboard_uuid=target_dashboard_uuid,
+                           target_dashboard_name=target_dashboard_name,
                            **template_context)
 
 

--- a/application/controllers/admin/dashboards.py
+++ b/application/controllers/admin/dashboards.py
@@ -9,7 +9,9 @@ from flask import (
     flash, redirect, render_template, request,
     session, url_for
 )
-from application.forms import convert_to_dashboard_form
+from application.forms import(
+    convert_to_dashboard_form,
+    convert_to_module_for_form)
 
 import cgi
 import json
@@ -50,6 +52,11 @@ def update_modules_form_and_redirect(func):
         if uuid is not None:
             session['pending_dashboard']['uuid'] = uuid
 
+        if 'clone_module' in request.form:
+            url = url_for('clone_module',
+                          target_dashboard_uuid=uuid)
+            return redirect(url)
+
         if 'add_section' in request.form:
             url = url_for('dashboard_form',
                           uuid=uuid,
@@ -89,17 +96,29 @@ def dashboard_form(admin_client, uuid=None):
             return True
         return False
 
+    def append_cloned_module():
+        if request.args.get('clone_module'):
+            module = admin_client.get_module(
+                request.args.get('clone_module'))
+            module_form = convert_to_module_for_form(
+                module, module_types, cloned=True)
+            form.modules.append_entry(module_form)
+            add_select_options_to_module()
+
     def append_new_module_forms():
         total_modules = int(request.args.get('modules'))
         modules_required = total_modules - len(form.modules)
         for i in range(modules_required):
             form.modules.append_entry()
-            choices = module_types.get_visualisation_choices()
-            form.modules[-1].module_type.choices = choices
-            choices = data_sources.group_choices()
-            form.modules[-1].data_group.choices = choices
-            choices = data_sources.type_choices()
-            form.modules[-1].data_type.choices = choices
+            add_select_options_to_module()
+
+    def add_select_options_to_module():
+        choices = module_types.get_visualisation_choices()
+        form.modules[-1].module_type.choices = choices
+        choices = data_sources.group_choices()
+        form.modules[-1].data_group.choices = choices
+        choices = data_sources.type_choices()
+        form.modules[-1].data_type.choices = choices
 
     template_context = base_template_context()
     template_context['user'] = session['oauth_user']
@@ -131,9 +150,60 @@ def dashboard_form(admin_client, uuid=None):
         append_new_module_forms()
         if request.args.get('section'):
             form.modules[-1].category.data = 'container'
+    if request.args.get('clone_module'):
+        append_cloned_module()
 
     return render_template('admin/dashboards/create.html',
                            form=form,
+                           **template_context)
+
+
+@app.route('{0}/clone_module/<target_dashboard_uuid>'.format(
+    DASHBOARD_ROUTE), methods=['POST', 'GET'])
+@app.route('{0}/clone_module'.format(
+    DASHBOARD_ROUTE), methods=['POST', 'GET'])
+@requires_authentication
+@requires_permission('dashboard')
+def clone_module(admin_client, target_dashboard_uuid=None):
+    modules = None
+    dashboards = None
+    target_dashboard_url = None
+    source_dashboard_uuid = None
+    selected_dashboard = None
+
+    dashboards_url = '{0}/dashboards'.format(
+        app.config['STAGECRAFT_HOST'])
+    access_token = session['oauth_token']['access_token']
+    headers = {
+        'Authorization': 'Bearer {0}'.format(access_token),
+    }
+    dashboard_response = requests.get(dashboards_url, headers=headers)
+    if dashboard_response.status_code == 200:
+        dashboards = dashboard_response.json()['dashboards']
+        if request.form and 'dashboard_uuid' in request.form:
+            source_dashboard_uuid = request.form['dashboard_uuid']
+            modules = admin_client.list_modules_on_dashboard(
+                source_dashboard_uuid)
+            selected_dashboard = next(
+                dashboard for dashboard in dashboards
+                if dashboard['id'] == source_dashboard_uuid)
+
+    if target_dashboard_uuid:
+        target_dashboard_url = '/admin/dashboards/{}'.format(
+            target_dashboard_uuid)
+    else:
+        target_dashboard_url = '/admin/dashboards/new'
+
+    template_context = base_template_context()
+    template_context['user'] = session['oauth_user']
+
+    return render_template('dashboards/clone_module.html',
+                           modules=modules,
+                           dashboards=dashboards,
+                           target_dashboard_url=target_dashboard_url,
+                           source_dashboard_uuid=source_dashboard_uuid,
+                           selected_dashboard=selected_dashboard,
+                           target_dashboard_uuid=target_dashboard_uuid,
                            **template_context)
 
 

--- a/application/templates/admin/dashboards/create.html
+++ b/application/templates/admin/dashboards/create.html
@@ -33,6 +33,9 @@
           <input type="submit" class="btn btn-default" value="Add a module" name="add_module">
         </p>
         <p>
+          <input type="submit" class="btn btn-default" value="Clone a module" name="clone_module">
+        </p>
+        <p>
         {% if uuid %}
         <input type="submit" class="btn btn-success" value="Update dashboard" name="create">
         {% else %}

--- a/application/templates/dashboards/clone_module.html
+++ b/application/templates/dashboards/clone_module.html
@@ -5,10 +5,11 @@
   <div class="row">
     <div class="col-lg-12">
       {% if dashboards %}
+        <h3>Cloning into <a href={{target_dashboard_url}}>{{target_dashboard_name}} <span class="glyphicon glyphicon-share-alt"></span></a></h1>
         <form method="post" action="{{ url_for('clone_module', target_dashboard_uuid=target_dashboard_uuid) }}" role="form" class="form-inline">
           <div class='form-group'>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <label for="dashboard_uuid">Select dashboard: </label>
+            <label for="dashboard_uuid">Select source dashboard: </label>
             <select class='form-control' name="dashboard_uuid" id="dashboard-uuid">
             {% for dashboard in dashboards %}
               {% if(source_dashboard_uuid == dashboard.id) %}
@@ -25,14 +26,16 @@
             <input type="submit" class="btn btn-default" value="Get modules" name="modules_for_dashboard">
             {% if modules %}
             <div class="btn-group">
-              <button class="btn btn-primary dropdown-toggle" type="button" id="module-select" data-toggle="dropdown" aria-expanded="true">
-                Select modules from {{selected_dashboard.title}}
+              <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="true" id="module-uuid">
+                Select module
                 <span class="caret"></span>
               </button>
               <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="module-select">
                 {% for module in modules %}
                   <li role="presentation">
-                    <a role="menuitem" tabindex="-1" href="{{'{}?clone_module={}'.format(target_dashboard_url, module.id)}}">{{ module.title }}</a>
+                    <a role="menuitem" tabindex="-1" href="{{'{}?clone_module={}'.format(target_dashboard_url, module.id)}}">
+                      Clone <span class="bold">{{ module.title }}</span> into <span class="bold">{{target_dashboard_name}}</span> <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                    </a>
                   </li>
                 {% endfor %}
               </ul>

--- a/application/templates/dashboards/clone_module.html
+++ b/application/templates/dashboards/clone_module.html
@@ -1,0 +1,53 @@
+
+{% extends "base.html" %}
+
+{% block body %}
+  <div class="row">
+    <div class="col-lg-12">
+      {% if dashboards %}
+        <form method="post" action="{{ url_for('clone_module', target_dashboard_uuid=target_dashboard_uuid) }}" role="form" class="form-inline">
+          <div class='form-group'>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <label for="dashboard_uuid">Select dashboard: </label>
+            <select class='form-control' name="dashboard_uuid" id="dashboard-uuid">
+            {% for dashboard in dashboards %}
+              {% if(source_dashboard_uuid == dashboard.id) %}
+                  <option selected value="{{dashboard.id}}">
+                    {{ dashboard.title }}
+                  </option>
+              {% else %}
+                  <option value="{{dashboard.id}}">
+                    {{ dashboard.title }}
+                  </option>
+              {% endif %}
+            {% endfor %}
+            </select>
+            <input type="submit" class="btn btn-default" value="Get modules" name="modules_for_dashboard">
+            {% if modules %}
+            <div class="btn-group">
+              <button class="btn btn-primary dropdown-toggle" type="button" id="module-select" data-toggle="dropdown" aria-expanded="true">
+                Select modules from {{selected_dashboard.title}}
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="module-select">
+                {% for module in modules %}
+                  <li role="presentation">
+                    <a role="menuitem" tabindex="-1" href="{{'{}?clone_module={}'.format(target_dashboard_url, module.id)}}">{{ module.title }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+          </div>
+        </form>
+      {% endif %}
+    </div><!-- /.col-lg-6 -->
+  </div><!-- /.row -->
+{% endblock %}
+
+{% block footer_javascripts %}
+    <script src='/static/javascripts/jsonlint/jsonlint.js'></script>
+    <script src='/static/javascripts/sticky-kit/sticky-kit.js'></script>
+    <script src='/static/javascripts/sortable/jquery.sortable.min.js'></script>
+<script src='/static/javascripts/edit_dashboard.js'></script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2
-performanceplatform-client==0.8.4
+performanceplatform-client==0.9.6
 pyasn1==0.1.7
 pyOpenSSL==0.14
 pytz==2014.4

--- a/tests/application/controllers/admin/test_dashboards.py
+++ b/tests/application/controllers/admin/test_dashboards.py
@@ -520,6 +520,7 @@ class DashboardTestCase(FlaskAppTestCase):
             source_dashboard_uuid=None,
             selected_dashboard=None,
             target_dashboard_uuid=None,
+            target_dashboard_name='new dashboard',
             user={'permissions': ['signin', 'dashboard']},
             environment={'human_name': 'Development', 'name': 'development'},
             target_dashboard_url='/admin/dashboards/new')
@@ -535,6 +536,10 @@ class DashboardTestCase(FlaskAppTestCase):
             mock_list_data_sets,
             mock_list_module_types,
             client):
+        with client.session_transaction() as session:
+            session['pending_dashboard'] = {
+                'title': 'Dashboard title!'
+            }
         mock_render.return_value = ''
         dashboards = {'dashboards': [
             {
@@ -559,6 +564,7 @@ class DashboardTestCase(FlaskAppTestCase):
             source_dashboard_uuid=None,
             selected_dashboard=None,
             target_dashboard_uuid='target_dashboard_uuid',
+            target_dashboard_name='Dashboard title!',
             user={'permissions': ['signin', 'dashboard']},
             environment={'human_name': 'Development', 'name': 'development'},
             target_dashboard_url='/admin/dashboards/target_dashboard_uuid')
@@ -612,6 +618,7 @@ class DashboardTestCase(FlaskAppTestCase):
             source_dashboard_uuid='uuid',
             selected_dashboard=dashboards['dashboards'][0],
             target_dashboard_uuid=None,
+            target_dashboard_name='new dashboard',
             user={'permissions': ['signin', 'dashboard']},
             environment={'human_name': 'Development', 'name': 'development'},
             target_dashboard_url='/admin/dashboards/new')
@@ -630,6 +637,10 @@ class DashboardTestCase(FlaskAppTestCase):
             mock_list_data_sets,
             mock_list_module_types,
             client):
+        with client.session_transaction() as session:
+            session['pending_dashboard'] = {
+                'title': 'Dashboard title!'
+            }
         mock_render.return_value = ''
         dashboards = {'dashboards': [
             {
@@ -665,6 +676,7 @@ class DashboardTestCase(FlaskAppTestCase):
             source_dashboard_uuid='uuid',
             selected_dashboard=dashboards['dashboards'][0],
             target_dashboard_uuid='target_dashboard_uuid',
+            target_dashboard_name='Dashboard title!',
             user={'permissions': ['signin', 'dashboard']},
             environment={'human_name': 'Development', 'name': 'development'},
             target_dashboard_url='/admin/dashboards/target_dashboard_uuid')

--- a/tests/application/controllers/admin/test_dashboards.py
+++ b/tests/application/controllers/admin/test_dashboards.py
@@ -335,6 +335,340 @@ class DashboardTestCase(FlaskAppTestCase):
             contains_string('admin/dashboards/new?modules=1')
         )
 
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_clone_module_new_dashboard_redirects_with_correct_query_params(
+            self,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        resp = client.post('/admin/dashboards',
+                           data={'clone_module': 1})
+
+        assert_that(resp.status_code, equal_to(302))
+        assert_that(
+            resp.headers['location'],
+            ends_with('/clone_module'))
+
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_clone_module_existing_dashboard_redirects_correct_query_params(
+            self,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        dashboard_id = "def123abc"
+        resp = client.post('/admin/dashboards/{}'.format(dashboard_id),
+                           data={'clone_module': 1})
+
+        assert_that(resp.status_code, equal_to(302))
+        assert_that(
+            resp.headers['location'],
+            ends_with('/clone_module/{}'
+                      .format(dashboard_id))
+        )
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_module")
+    @patch("application.controllers.admin.dashboards.render_template")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_clone_module_appends_to_the_form_with_the_correct_modules(
+            self,
+            mock_render,
+            mock_get_module,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        with open(os.path.join(
+                  os.path.dirname(__file__),
+                  '../../../fixtures/example-dashboard.json')) as file:
+            module_dict = json.loads(file.read())['modules'][0]
+        mock_render.return_value = ''
+        mock_get_module.return_value = module_dict
+        module_id = "abc123def"
+        resp = client.get(
+            'admin/dashboards/new?clone_module={}'.format(module_id))
+
+        rendered_template = 'admin/dashboards/create.html'
+        assert_that(mock_render.call_args[0][0], equal_to(rendered_template))
+        kwargs = mock_render.call_args[1]
+        form = kwargs['form']
+        modules = form.modules
+        assert_that(len(modules), equal_to(1))
+        cloned_module = form.modules[0]
+        assert_that(
+            cloned_module['id'].data, equal_to(None))
+        assert_that(
+            cloned_module['module_type'].data, equal_to(
+                module_dict['module_type']))
+        assert_that(
+            cloned_module['data_group'].data, equal_to(
+                module_dict['data_group']))
+        assert_that(
+            cloned_module['data_type'].data, equal_to(
+                module_dict['data_type']))
+        assert_that(
+            cloned_module['slug'].data, equal_to(module_dict['slug']))
+        assert_that(
+            cloned_module['title'].data, equal_to(module_dict['title']))
+        assert_that(
+            cloned_module['description'].data, equal_to(
+                module_dict['description']))
+        assert_that(
+            cloned_module['info'].data, equal_to(module_dict['info']))
+        assert_that(
+            cloned_module['query_parameters'].data, equal_to(
+                module_dict['query_parameters']))
+        assert_that(
+            cloned_module['options'].data, equal_to(module_dict['options']))
+        assert_that(resp.status_code, equal_to(200))
+
+    @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")
+    @patch("performanceplatform.client.admin.AdminAPI.get_module")
+    @patch("application.controllers.admin.dashboards.render_template")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_clone_module_appends_correct_modules_to_form_existing_dashboard(
+            self,
+            mock_render,
+            mock_get_module,
+            mock_get_dashboard,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        dashboard_id = "def123abc"
+        with open(os.path.join(
+                  os.path.dirname(__file__),
+                  '../../../fixtures/example-dashboard.json')) as file:
+            dashboard_dict = json.loads(file.read())
+            module_dict = dashboard_dict['modules'][0].copy()
+        mock_render.return_value = ''
+        mock_get_module.return_value = module_dict
+        mock_get_dashboard.return_value = dashboard_dict
+        module_id = "abc123def"
+        # modules are seven because there is a section in the example data
+        resp = client.get(
+            'admin/dashboards/{}?clone_module={}'.format(
+                dashboard_id, module_id))
+
+        rendered_template = 'admin/dashboards/create.html'
+        assert_that(mock_render.call_args[0][0], equal_to(rendered_template))
+        kwargs = mock_render.call_args[1]
+        form = kwargs['form']
+        modules = form.modules
+        assert_that(len(modules), equal_to(7))
+        cloned_module = form.modules[-1]
+        assert_that(
+            cloned_module['id'].data, equal_to(None))
+        assert_that(
+            cloned_module['module_type'].data, equal_to(
+                module_dict['module_type']))
+        assert_that(
+            cloned_module['data_group'].data, equal_to(
+                module_dict['data_group']))
+        assert_that(
+            cloned_module['data_type'].data, equal_to(
+                module_dict['data_type']))
+        assert_that(
+            cloned_module['slug'].data, equal_to(module_dict['slug']))
+        assert_that(
+            cloned_module['title'].data, equal_to(module_dict['title']))
+        assert_that(
+            cloned_module['description'].data, equal_to(
+                module_dict['description']))
+        assert_that(
+            cloned_module['info'].data, equal_to(module_dict['info']))
+        assert_that(
+            cloned_module['query_parameters'].data, equal_to(
+                module_dict['query_parameters']))
+        assert_that(
+            cloned_module['options'].data, equal_to(module_dict['options']))
+        assert_that(resp.status_code, equal_to(200))
+
+    @patch('requests.get')
+    @patch("application.controllers.admin.dashboards.render_template")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_get_clone_module_no_target_uuid_renders_with_correct_args(
+            self,
+            mock_render,
+            get_patch,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        mock_render.return_value = ''
+        dashboards = {'dashboards': [
+            {
+                'url': 'http://stagecraft/dashboard/uuid',
+                'public-url': 'http://spotlight/performance/carers-allowance',
+                'published': True,
+                'id': 'uuid',
+                'title': 'Name of service'
+            }
+        ]}
+        response = requests.Response()
+        response.status_code = 200
+        response.json = Mock(return_value=dashboards)
+        get_patch.return_value = response
+        client.get(
+            'admin/dashboards/clone_module')
+        rendered_template = 'dashboards/clone_module.html'
+        mock_render.assert_called_once_with(
+            rendered_template,
+            modules=None,
+            dashboards=dashboards['dashboards'],
+            source_dashboard_uuid=None,
+            selected_dashboard=None,
+            target_dashboard_uuid=None,
+            user={'permissions': ['signin', 'dashboard']},
+            environment={'human_name': 'Development', 'name': 'development'},
+            target_dashboard_url='/admin/dashboards/new')
+
+    @patch('requests.get')
+    @patch("application.controllers.admin.dashboards.render_template")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_get_clone_module_with_target_uuid_renders_with_correct_args(
+            self,
+            mock_render,
+            get_patch,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        mock_render.return_value = ''
+        dashboards = {'dashboards': [
+            {
+                'url': 'http://stagecraft/dashboard/uuid',
+                'public-url': 'http://spotlight/performance/carers-allowance',
+                'published': True,
+                'id': 'uuid',
+                'title': 'Name of service'
+            }
+        ]}
+        response = requests.Response()
+        response.status_code = 200
+        response.json = Mock(return_value=dashboards)
+        get_patch.return_value = response
+        client.get(
+            'admin/dashboards/clone_module/target_dashboard_uuid')
+        rendered_template = 'dashboards/clone_module.html'
+        mock_render.assert_called_once_with(
+            rendered_template,
+            modules=None,
+            dashboards=dashboards['dashboards'],
+            source_dashboard_uuid=None,
+            selected_dashboard=None,
+            target_dashboard_uuid='target_dashboard_uuid',
+            user={'permissions': ['signin', 'dashboard']},
+            environment={'human_name': 'Development', 'name': 'development'},
+            target_dashboard_url='/admin/dashboards/target_dashboard_uuid')
+
+    @patch('requests.get')
+    @patch("application.controllers.admin.dashboards.render_template")
+    @patch(
+        "performanceplatform.client.admin.AdminAPI.list_modules_on_dashboard")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_post_clone_module_no_target_uuid_renders_with_correct_args(
+            self,
+            mock_list_modules_on_dashboard,
+            mock_render,
+            get_patch,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        mock_render.return_value = ''
+        dashboards = {'dashboards': [
+            {
+                'url': 'http://stagecraft/dashboard/uuid',
+                'public-url': 'http://spotlight/performance/carers-allowance',
+                'published': True,
+                'id': 'uuid',
+                'title': 'Name of service'
+            }
+        ]}
+        modules = [
+            {
+                'id': 'abc',
+                'title': 'def'
+            }
+        ]
+
+        response = requests.Response()
+        response.status_code = 200
+        response.json = Mock(return_value=dashboards)
+        get_patch.return_value = response
+
+        mock_list_modules_on_dashboard.return_value = modules
+
+        client.post(
+            'admin/dashboards/clone_module',
+            data={'dashboard_uuid': 'uuid'})
+        rendered_template = 'dashboards/clone_module.html'
+        mock_render.assert_called_once_with(
+            rendered_template,
+            modules=[{'id': 'abc', 'title': 'def'}],
+            dashboards=dashboards['dashboards'],
+            source_dashboard_uuid='uuid',
+            selected_dashboard=dashboards['dashboards'][0],
+            target_dashboard_uuid=None,
+            user={'permissions': ['signin', 'dashboard']},
+            environment={'human_name': 'Development', 'name': 'development'},
+            target_dashboard_url='/admin/dashboards/new')
+
+    @patch('requests.get')
+    @patch("application.controllers.admin.dashboards.render_template")
+    @patch(
+        "performanceplatform.client.admin.AdminAPI.list_modules_on_dashboard")
+    @signed_in(permissions=['signin', 'dashboard'])
+    def test_post_clone_module_with_target_uuid_renders_with_correct_args(
+            self,
+            mock_list_modules_on_dashboard,
+            mock_render,
+            get_patch,
+            mock_list_organisations,
+            mock_list_data_sets,
+            mock_list_module_types,
+            client):
+        mock_render.return_value = ''
+        dashboards = {'dashboards': [
+            {
+                'url': 'http://stagecraft/dashboard/uuid',
+                'public-url': 'http://spotlight/performance/carers-allowance',
+                'published': True,
+                'id': 'uuid',
+                'title': 'Name of service'
+            }
+        ]}
+        modules = [
+            {
+                'id': 'abc',
+                'title': 'def'
+            }
+        ]
+
+        response = requests.Response()
+        response.status_code = 200
+        response.json = Mock(return_value=dashboards)
+        get_patch.return_value = response
+
+        mock_list_modules_on_dashboard.return_value = modules
+
+        client.post(
+            'admin/dashboards/clone_module/target_dashboard_uuid',
+            data={'dashboard_uuid': 'uuid'})
+        rendered_template = 'dashboards/clone_module.html'
+        mock_render.assert_called_once_with(
+            rendered_template,
+            modules=[{'id': 'abc', 'title': 'def'}],
+            dashboards=dashboards['dashboards'],
+            source_dashboard_uuid='uuid',
+            selected_dashboard=dashboards['dashboards'][0],
+            target_dashboard_uuid='target_dashboard_uuid',
+            user={'permissions': ['signin', 'dashboard']},
+            environment={'human_name': 'Development', 'name': 'development'},
+            target_dashboard_url='/admin/dashboards/target_dashboard_uuid')
+
     @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
     def test_updating_existing_dashboard(self,
                                          update_mock,


### PR DESCRIPTION
Ready to go once Urmy gives the go ahead.

When the user clicks 'Clone module' on a new or existing dashboard it
will redirect to a page containing a dropdown of dashboards to select
from and the form progress will be saved in the session (because of the
update_modules_form_and_redirect decorator). When the user selects a
dashboard and submits it will redirect back to the page, but now there
will also be a dropdown containing modules on the selected dashboard.
Clicking a link in this dropdown will redirect to the original dashboard
page with the module now appended to the form using the following
mechanism:

A link of the format 'admin/dashboards/new?clone_module={module_id}' or 'admin/dashboards/dashboard_uuid?clone_module={module_id}' which when followed will redirect to a new or the existing dashboard with anything in the session still there and the new module prefilled and present.

Before merging I will deploy to preview and get @theotherurmy  to have a look.

This could be tidied up a bit if this: https://github.com/alphagov/performanceplatform-client.py/pull/58 was merged.