### PR TITLE
Add closing tag for .sortable-ghost

### DIFF
--- a/application/assets/scss/performanceplatform-admin/style.scss
+++ b/application/assets/scss/performanceplatform-admin/style.scss
@@ -254,6 +254,7 @@ ul.checkbox-set {
   background-color: #ccc;
   border-radius: 3px;
   color: black;
+}
 
 .steps {
   padding-bottom: 10px;


### PR DESCRIPTION
The styles are broken after a deploy. If seems this crept in during the
rebase from looking at the history.