### PR TITLE
Make Dashboards and Modules compatible with the changes to the views in Stagecraft.

### DIFF
--- a/application/controllers/admin/dashboards.py
+++ b/application/controllers/admin/dashboards.py
@@ -179,7 +179,7 @@ def clone_module(admin_client, target_dashboard_uuid=None):
     }
     dashboard_response = requests.get(dashboards_url, headers=headers)
     if dashboard_response.status_code == 200:
-        dashboards = dashboard_response.json()['dashboards']
+        dashboards = dashboard_response.json()
         if request.form and 'dashboard_uuid' in request.form:
             source_dashboard_uuid = request.form['dashboard_uuid']
             modules = admin_client.list_modules_on_dashboard(
@@ -324,6 +324,7 @@ def build_dict_for_post(form, module_types):
             'order': index,
             'modules': [],
         })
+
     return {
         'published': form.published.data == 'True',
         'page-type': 'dashboard',
@@ -348,8 +349,10 @@ def build_dict_for_post(form, module_types):
 
 def format_error(verb, form, error):
     if isinstance(error, requests.HTTPError):
+        error_message = error.response.content if error.response.content \
+            else error.message
         return 'Error {} the {} dashboard: {}'.format(
-            verb, form.slug.data, error.response.json()['message'])
+            verb, form.slug.data, error_message)
     elif isinstance(error, InvalidFormFieldError):
         return 'Error {} the {} dashboard: {}'.format(
             verb, form.slug.data, to_error_list(form.errors))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2
-performanceplatform-client==0.9.6
+performanceplatform-client==0.10.1
 pyasn1==0.1.7
 pyOpenSSL==0.14
 pytz==2014.4

--- a/tests/application/controllers/admin/test_dashboards.py
+++ b/tests/application/controllers/admin/test_dashboards.py
@@ -497,7 +497,7 @@ class DashboardTestCase(FlaskAppTestCase):
             mock_list_module_types,
             client):
         mock_render.return_value = ''
-        dashboards = {'dashboards': [
+        dashboards = [
             {
                 'url': 'http://stagecraft/dashboard/uuid',
                 'public-url': 'http://spotlight/performance/carers-allowance',
@@ -505,7 +505,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'id': 'uuid',
                 'title': 'Name of service'
             }
-        ]}
+        ]
         response = requests.Response()
         response.status_code = 200
         response.json = Mock(return_value=dashboards)
@@ -516,7 +516,7 @@ class DashboardTestCase(FlaskAppTestCase):
         mock_render.assert_called_once_with(
             rendered_template,
             modules=None,
-            dashboards=dashboards['dashboards'],
+            dashboards=dashboards,
             source_dashboard_uuid=None,
             selected_dashboard=None,
             target_dashboard_uuid=None,
@@ -541,7 +541,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'title': 'Dashboard title!'
             }
         mock_render.return_value = ''
-        dashboards = {'dashboards': [
+        dashboards = [
             {
                 'url': 'http://stagecraft/dashboard/uuid',
                 'public-url': 'http://spotlight/performance/carers-allowance',
@@ -549,7 +549,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'id': 'uuid',
                 'title': 'Name of service'
             }
-        ]}
+        ]
         response = requests.Response()
         response.status_code = 200
         response.json = Mock(return_value=dashboards)
@@ -560,7 +560,7 @@ class DashboardTestCase(FlaskAppTestCase):
         mock_render.assert_called_once_with(
             rendered_template,
             modules=None,
-            dashboards=dashboards['dashboards'],
+            dashboards=dashboards,
             source_dashboard_uuid=None,
             selected_dashboard=None,
             target_dashboard_uuid='target_dashboard_uuid',
@@ -584,7 +584,7 @@ class DashboardTestCase(FlaskAppTestCase):
             mock_list_module_types,
             client):
         mock_render.return_value = ''
-        dashboards = {'dashboards': [
+        dashboards = [
             {
                 'url': 'http://stagecraft/dashboard/uuid',
                 'public-url': 'http://spotlight/performance/carers-allowance',
@@ -592,7 +592,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'id': 'uuid',
                 'title': 'Name of service'
             }
-        ]}
+        ]
         modules = [
             {
                 'id': 'abc',
@@ -614,9 +614,9 @@ class DashboardTestCase(FlaskAppTestCase):
         mock_render.assert_called_once_with(
             rendered_template,
             modules=[{'id': 'abc', 'title': 'def'}],
-            dashboards=dashboards['dashboards'],
+            dashboards=dashboards,
             source_dashboard_uuid='uuid',
-            selected_dashboard=dashboards['dashboards'][0],
+            selected_dashboard=dashboards[0],
             target_dashboard_uuid=None,
             target_dashboard_name='new dashboard',
             user={'permissions': ['signin', 'dashboard']},
@@ -642,7 +642,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'title': 'Dashboard title!'
             }
         mock_render.return_value = ''
-        dashboards = {'dashboards': [
+        dashboards = [
             {
                 'url': 'http://stagecraft/dashboard/uuid',
                 'public-url': 'http://spotlight/performance/carers-allowance',
@@ -650,7 +650,7 @@ class DashboardTestCase(FlaskAppTestCase):
                 'id': 'uuid',
                 'title': 'Name of service'
             }
-        ]}
+        ]
         modules = [
             {
                 'id': 'abc',
@@ -672,9 +672,9 @@ class DashboardTestCase(FlaskAppTestCase):
         mock_render.assert_called_once_with(
             rendered_template,
             modules=[{'id': 'abc', 'title': 'def'}],
-            dashboards=dashboards['dashboards'],
+            dashboards=dashboards,
             source_dashboard_uuid='uuid',
-            selected_dashboard=dashboards['dashboards'][0],
+            selected_dashboard=dashboards[0],
             target_dashboard_uuid='target_dashboard_uuid',
             target_dashboard_name='Dashboard title!',
             user={'permissions': ['signin', 'dashboard']},


### PR DESCRIPTION
The error message received sent from the Resource View in
Stagecraft to the Performance Platform Client is a string, not
json.  The function that formats the errors returned on screen
to the user has been updated to reflect that.

Depends on the stagecraft changes in PR: 
https://github.com/alphagov/stagecraft/pull/353