### PR TITLE
Change Redis key prefix

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -23,7 +23,7 @@ app.redis_instance = Redis(
     port=app.config['REDIS_PORT'],
 )
 app.session_interface = RedisSessionInterface(
-    redis=app.redis_instance, prefix='admin_app:session:')
+    redis=app.redis_instance, prefix='performanceplatform_admin:session:')
 
 # adds uncaught exception handlers to app and submits to sentry
 # this will only send when SENTRY_DSN is defined in config


### PR DESCRIPTION
The admin app is going to be hosted in the GOV.UK Backend vDC, where it will share Redis with other apps like the GOV.UK crawler worker.

Change the Redis key prefix to be more specific so that we have less chance of clashing with other apps.