### PR TITLE
Fix cost per transaction query parameter

### DIFF
--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -47,7 +47,7 @@ def get_module_config_for_cost_per_transaction(owning_organisation):
             "type": "currency"
         },
         "query_parameters": {
-            "sort_by": "_timestamp:descending"
+            "sort_by": "_timestamp:ascending"
         },
         "options": {
             "value-attribute": "count",


### PR DESCRIPTION
This should be ascending, to ensure the
time series module displays correctly.