### PR TITLE
Update cost-per-tx module config for schema

### DIFF
--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -29,12 +29,13 @@ from application.controllers.builder.common import(
 DATA_TYPE = 'cost-per-transaction'
 
 
-def get_module_config_for_cost_per_transaction(owning_organisation):
+def get_module_config_for_cost_per_transaction(module_type_id,
+                                               owning_organisation):
+
     module_config = {
         "slug": DATA_TYPE,
         "title": "Cost per transaction",
-        "module-type": "bar_chart_with_number",
-        "value-attribute": "count",
+        "type_id": module_type_id,
         "description": "",
         "info": ["Data source: {}".format(owning_organisation),
                  "<a href=\"https://www.gov.uk/service-manual/measurement/\
@@ -42,10 +43,6 @@ def get_module_config_for_cost_per_transaction(owning_organisation):
                 average cost of providing each successfully completed \
                 transaction, across all channels. Staff, IT and accommodation \
                 costs should be included."],
-        "format": {
-            "pence": True,
-            "type": "currency"
-        },
         "query_parameters": {
             "sort_by": "_timestamp:ascending"
         },
@@ -198,7 +195,10 @@ def upload_cost_per_transaction_file(admin_client, uuid):
     owning_organisation = (
         dashboard.get('organisation', {})).get("name", 'Unknown')
 
+    module_type_id = [t for t in admin_client.list_module_types()
+                      if t['name'] == 'single_timeseries'].pop()['id']
     module_config = get_module_config_for_cost_per_transaction(
+        module_type_id,
         owning_organisation)
 
     try:

--- a/tests/application/controllers/test_cost_per_transaction.py
+++ b/tests/application/controllers/test_cost_per_transaction.py
@@ -190,6 +190,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         get_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         add_module_to_dashboard_patch.return_value = {}
 
         self.file_data = {
@@ -254,6 +256,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         get_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         add_module_to_dashboard_patch.return_value = {}
 
         self.upload_spreadsheet_mock.return_value = \
@@ -317,6 +321,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         get_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         add_module_to_dashboard_patch.return_value = {}
 
         response = client.post(self.upload_url, data=self.file_data)
@@ -373,6 +379,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         get_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         add_module_to_dashboard_patch.return_value = {}
 
         client.post(self.upload_url, data=self.file_data)
@@ -382,8 +390,9 @@ class UploadPageTestCase(FlaskAppTestCase):
         assert_that(create_data_set_patch.called, equal_to(False))
         get_data_group_patch.assert_called_once_with("visas")
         assert_that(create_data_group_patch.called, equal_to(False))
-        list_module_types_patch.assert_called_once_with()
+        assert_that(list_module_types_patch.call_count, equal_to(2))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
+            'type_id': 'uuid',
             'data_group': 'visas',
             'data_type': 'cost-per-transaction',
             'title': 'Cost per transaction'})
@@ -430,6 +439,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         create_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         add_module_to_dashboard_patch.return_value = {}
 
         client.post(self.upload_url, data=self.file_data)
@@ -444,8 +455,9 @@ class UploadPageTestCase(FlaskAppTestCase):
             'max_age_expected': 0})
         get_data_group_patch.assert_called_once_with("visas")
         create_data_group_patch.assert_called_once_with({'name': 'visas'})
-        list_module_types_patch.assert_called_once_with()
+        assert_that(list_module_types_patch.call_count, equal_to(2))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
+            'type_id': 'uuid',
             'data_group': 'visas',
             'data_type': 'cost-per-transaction',
             'title': 'Cost per transaction'})
@@ -477,6 +489,9 @@ class UploadPageTestCase(FlaskAppTestCase):
 
         get_dashboard_patch.return_value = {
             'slug': 'visas'}
+
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
 
         # ===
         response_json_mock = Mock()
@@ -534,6 +549,9 @@ class UploadPageTestCase(FlaskAppTestCase):
 
         get_dashboard_patch.return_value = {
             'slug': 'visas'}
+
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
 
         # ===
         response_json_mock = Mock()
@@ -604,6 +622,8 @@ class UploadPageTestCase(FlaskAppTestCase):
         get_data_group_patch.return_value = {
             'name': 'visas'
         }
+        list_module_types_patch.return_value = [{'name': 'single_timeseries',
+                                                 'id': 'uuid'}]
         # ===
         response = Mock()
         response.status_code = 400
@@ -631,8 +651,9 @@ class UploadPageTestCase(FlaskAppTestCase):
         assert_that(create_data_set_patch.called, equal_to(False))
         get_data_group_patch.assert_called_once_with("visas")
         assert_that(create_data_group_patch.called, equal_to(False))
-        list_module_types_patch.assert_called_once_with()
+        assert_that(list_module_types_patch.call_count, equal_to(2))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
+            'type_id': 'uuid',
             'data_group': 'visas',
             'data_type': 'cost-per-transaction',
             'title': 'Cost per transaction'})


### PR DESCRIPTION
Changes to the stagecraft schema for modules
showed that the CPT module builder was using
an inadequate config. This fixes the config
to work with the new schema and updates the
tests.