### PR TITLE
Add Cache-Control header to all requests

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -45,6 +45,11 @@ import application.controllers.builder.cost_per_transaction
 import application.controllers.admin.transforms
 import application.controllers.upload
 
+@app.after_request
+def add_header(response):
+    response.headers['Cache-Control'] = 'public, max-age=0'
+    return response
+
 
 def start(port):
     app.debug = app.config['DEBUG'] or False


### PR DESCRIPTION
The lack of a Cache-Control header makes some upstream hosts assume that requests to this app can be cached.

Add a Cache-Control header for all requests so that they aren't cache by things upstream from us.

This should be improved in the future so that requests for cacheable resources are actually cached.