### PR TITLE
Fetch environment from config

### DIFF
--- a/application/helpers.py
+++ b/application/helpers.py
@@ -10,7 +10,7 @@ from requests_oauthlib import OAuth2Session
 from requests import Timeout, ConnectionError
 
 
-environment = getenv('INFRASTRUCTURE_ENV', 'development')
+environment = app.config.get('ENVIRONMENT', 'development')
 
 
 @app.context_processor


### PR DESCRIPTION
There's no easy way to set the environment in an environment variable on the GOV.UK infrastructure. It's much easier to add a setting at deployment time which indicates the environment.