### PR TITLE
Remove unnecessary module types lookup

### DIFF
--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -29,13 +29,11 @@ from application.controllers.builder.common import(
 DATA_TYPE = 'cost-per-transaction'
 
 
-def get_module_config_for_cost_per_transaction(module_type_id,
-                                               owning_organisation):
+def get_module_config_for_cost_per_transaction(owning_organisation):
 
     module_config = {
         "slug": DATA_TYPE,
         "title": "Cost per transaction",
-        "type_id": module_type_id,
         "description": "",
         "info": ["Data source: {}".format(owning_organisation),
                  "<a href=\"https://www.gov.uk/service-manual/measurement/\
@@ -195,10 +193,7 @@ def upload_cost_per_transaction_file(admin_client, uuid):
     owning_organisation = (
         dashboard.get('organisation', {})).get("name", 'Unknown')
 
-    module_type_id = [t for t in admin_client.list_module_types()
-                      if t['name'] == 'single_timeseries'].pop()['id']
     module_config = get_module_config_for_cost_per_transaction(
-        module_type_id,
         owning_organisation)
 
     try:

--- a/tests/application/controllers/test_cost_per_transaction.py
+++ b/tests/application/controllers/test_cost_per_transaction.py
@@ -390,7 +390,7 @@ class UploadPageTestCase(FlaskAppTestCase):
         assert_that(create_data_set_patch.called, equal_to(False))
         get_data_group_patch.assert_called_once_with("visas")
         assert_that(create_data_group_patch.called, equal_to(False))
-        assert_that(list_module_types_patch.call_count, equal_to(2))
+        assert_that(list_module_types_patch.call_count, equal_to(1))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
             'type_id': 'uuid',
             'data_group': 'visas',
@@ -455,7 +455,7 @@ class UploadPageTestCase(FlaskAppTestCase):
             'max_age_expected': 0})
         get_data_group_patch.assert_called_once_with("visas")
         create_data_group_patch.assert_called_once_with({'name': 'visas'})
-        assert_that(list_module_types_patch.call_count, equal_to(2))
+        assert_that(list_module_types_patch.call_count, equal_to(1))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
             'type_id': 'uuid',
             'data_group': 'visas',
@@ -651,7 +651,7 @@ class UploadPageTestCase(FlaskAppTestCase):
         assert_that(create_data_set_patch.called, equal_to(False))
         get_data_group_patch.assert_called_once_with("visas")
         assert_that(create_data_group_patch.called, equal_to(False))
-        assert_that(list_module_types_patch.call_count, equal_to(2))
+        assert_that(list_module_types_patch.call_count, equal_to(1))
         add_module_to_dashboard_patch.assert_called_once_with('visas', {
             'type_id': 'uuid',
             'data_group': 'visas',


### PR DESCRIPTION
This was added as part of the module config
fix. We already look up the module types
in create_module_if_not_exists so this is
not needed.