### PR TITLE
Switch from admin edit to BIG EDIT

### DIFF
--- a/application/templates/dashboards/index.html
+++ b/application/templates/dashboards/index.html
@@ -27,7 +27,7 @@
                   {% if dashboard.status == "unpublished" %}
                     <li><a class='btn btn-success' href="{{ url_for('dashboard_hub', uuid=dashboard.id) }}">Edit dashboard</a></li>
                   {% endif %}
-                  <li><a class='btn btn-success' href="{{ url_for('dashboard_form', uuid=dashboard.id) }}">Admin edit</a></li>
+                  <li><a class='btn btn-success' href="{{ url_for('dashboard_form', uuid=dashboard.id) }}"><strong>BIG EDIT</strong></a></li>
                   <li><a class='btn btn-success' href="{{ url_for('dashboard_clone', uuid=dashboard.id) }}">Clone</a></li>
                   <li><a class='btn btn-primary' href="{{ dashboard['public-url'] }}" target="_blank">Preview</a></li>
               </ul>


### PR DESCRIPTION
Admin edit is unclear when you can also see the public facing edit
button. We need a name that differentiates the two in conversation and
we have already started using BIG EDIT. It is clearly superior.