### PR TITLE
Temporary single cost per transaction schema fix

### DIFF
--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -47,7 +47,7 @@ def get_module_config_for_cost_per_transaction(owning_organisation):
         "options": {
             "value-attribute": "count",
             "axis-period": "quarter",
-            "format": {
+            "format-options": {
                 "sigfigs": 4,
                 "type": "currency"
             }

--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -16,8 +16,6 @@ from application.helpers import (
 )
 from application import app
 
-import requests
-
 
 DASHBOARD_ROUTE = '/dashboards'
 
@@ -40,7 +38,8 @@ def dashboard_hub(admin_client, uuid):
     dashboard = Dashboard(**dashboard_dict)
     modules = []
     if "modules" in dashboard_dict.keys():
-        modules = [module["data_type"] for module in dashboard_dict["modules"]]
+        modules = [module["data_type"] for module in dashboard_dict["modules"]
+                   if 'data_type' in module]
     form = DashboardHubForm(obj=dashboard)
     if form.validate_on_submit():
         data = form.data

--- a/application/helpers.py
+++ b/application/helpers.py
@@ -212,7 +212,8 @@ def redirect_if_module_exists(module_name):
             dashboard_dict = admin_client.get_dashboard(uuid)
             if "modules" in dashboard_dict.keys():
                 data_types = [module["data_type"]
-                              for module in dashboard_dict["modules"]]
+                              for module in dashboard_dict["modules"]
+                              if 'data_type' in module]
                 if module_name in data_types:
                     flash("Module already exists", 'info')
                     return redirect(url_for(

--- a/tests/application/controllers/test_user_satisfaction.py
+++ b/tests/application/controllers/test_user_satisfaction.py
@@ -164,9 +164,10 @@ class AddUserSatisfactionTestCase(FlaskAppTestCase):
             'business_model': 'Department budget',
             'published': False,
             'status': 'unpublished',
-            'modules': [{
-                'data_type': 'user-satisfaction-score'
-            }]
+            'modules': [
+                {'data_type': 'user-satisfaction-score'},
+                {'slug': 'slug'}
+            ]
         }
 
         response = self.client.get(


### PR DESCRIPTION
The new stricter schema enforces this. Changing to format like
everything else is a pain as it requires a stagecraft data migration. We
will put in a story to do this in the future if people think this stop
gap is okay though.

Review after https://github.com/alphagov/performanceplatform-admin/pull/127