### PR TITLE
Ensure datasets are created with autoids

### DIFF
--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -87,7 +87,8 @@ def get_data_set_config(data_group_name, data_type):
         'data_group': data_group_name,
         'bearer_token': generate_bearer_token(),
         'upload_format': 'csv',
-        'max_age_expected': 0
+        'max_age_expected': 0,
+        'auto_ids': '_timestamp, end_at, period, channel'
     }
     return data_set_config
 

--- a/application/controllers/builder/cost_per_transaction.py
+++ b/application/controllers/builder/cost_per_transaction.py
@@ -47,7 +47,7 @@ def get_module_config_for_cost_per_transaction(owning_organisation):
         "options": {
             "value-attribute": "count",
             "axis-period": "quarter",
-            "format": {
+            "format-options": {
                 "sigfigs": 4,
                 "type": "currency"
             }

--- a/application/controllers/builder/digital_take_up.py
+++ b/application/controllers/builder/digital_take_up.py
@@ -219,8 +219,10 @@ def create_dataset_and_module(input_data_type,
         admin_client, data_group_name, input_data_type, uuid)
 
     # DATA SET
+    auto_ids = "_timestamp, channel, period"
     input_data_set = get_or_create_data_set(
-        admin_client, uuid, data_group['name'], input_data_type, period)
+        admin_client, uuid, data_group['name'], input_data_type, period,
+        auto_ids)
 
     if output_data_type:
         get_or_create_data_set(
@@ -313,10 +315,10 @@ def create_module_if_not_exists(admin_client,
 
 
 def get_or_create_data_set(admin_client, uuid, data_group, data_type,
-                           period):
+                           period, auto_ids=""):
 
     data_set_config = get_data_set_config(data_group, data_type,
-                                          period)
+                                          period, auto_ids)
 
     try:
         data_set = admin_client.get_data_set(
@@ -334,7 +336,7 @@ def get_or_create_data_set(admin_client, uuid, data_group, data_type,
     return data_set
 
 
-def get_data_set_config(data_group_name, data_type, period):
+def get_data_set_config(data_group_name, data_type, period, auto_ids=""):
     if period == 'week':
         max_age_expected = 1300000
     else:
@@ -345,8 +347,10 @@ def get_data_set_config(data_group_name, data_type, period):
         'data_group': data_group_name,
         'bearer_token': generate_bearer_token(),
         'upload_format': 'csv',
-        'max_age_expected': max_age_expected
+        'max_age_expected': max_age_expected,
     }
+    if auto_ids:
+        data_set_config['auto_ids'] = auto_ids
     return data_set_config
 
 

--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -16,8 +16,6 @@ from application.helpers import (
 )
 from application import app
 
-import requests
-
 
 DASHBOARD_ROUTE = '/dashboards'
 
@@ -40,7 +38,8 @@ def dashboard_hub(admin_client, uuid):
     dashboard = Dashboard(**dashboard_dict)
     modules = []
     if "modules" in dashboard_dict.keys():
-        modules = [module["data_type"] for module in dashboard_dict["modules"]]
+        modules = [module["data_type"] for module in dashboard_dict["modules"]
+                   if 'data_type' in module]
     form = DashboardHubForm(obj=dashboard)
     if form.validate_on_submit():
         data = form.data

--- a/application/helpers.py
+++ b/application/helpers.py
@@ -212,7 +212,8 @@ def redirect_if_module_exists(module_name):
             dashboard_dict = admin_client.get_dashboard(uuid)
             if "modules" in dashboard_dict.keys():
                 data_types = [module["data_type"]
-                              for module in dashboard_dict["modules"]]
+                              for module in dashboard_dict["modules"]
+                              if 'data_type' in module]
                 if module_name in data_types:
                     flash("Module already exists", 'info')
                     return redirect(url_for(

--- a/application/templates/dashboards/index.html
+++ b/application/templates/dashboards/index.html
@@ -27,7 +27,7 @@
                   {% if dashboard.status == "unpublished" %}
                     <li><a class='btn btn-success' href="{{ url_for('dashboard_hub', uuid=dashboard.id) }}">Edit dashboard</a></li>
                   {% endif %}
-                  <li><a class='btn btn-success' href="{{ url_for('dashboard_form', uuid=dashboard.id) }}">Admin edit</a></li>
+                  <li><a class='btn btn-success' href="{{ url_for('dashboard_form', uuid=dashboard.id) }}"><strong>BIG EDIT</strong></a></li>
                   <li><a class='btn btn-success' href="{{ url_for('dashboard_clone', uuid=dashboard.id) }}">Clone</a></li>
                   <li><a class='btn btn-primary' href="{{ dashboard['public-url'] }}" target="_blank">Preview</a></li>
               </ul>

--- a/tests/application/controllers/test_digital_take_up.py
+++ b/tests/application/controllers/test_digital_take_up.py
@@ -283,7 +283,6 @@ class ChannelOptionsPageTestCase(FlaskAppTestCase):
             client):
 
         get_data_group_patch.return_value = {'name': 'apply-uk-visa'}
-
         get_data_set_patch.return_value = None
 
         create_data_set_patch.return_value = self.CREATE_DATA_SET_RETURN_VALUE
@@ -297,6 +296,21 @@ class ChannelOptionsPageTestCase(FlaskAppTestCase):
         client.post(
             '/dashboard/dashboard-uuid/digital-take-up/channel-options',
             data=self.params())
+
+        create_data_set_patch.assert_any_call(match_equality(has_entries({
+            'data_group': 'apply-uk-visa',
+            'data_type': 'transactions-by-channel',
+            'auto_ids': '_timestamp, channel, period',
+            'max_age_expected': 1300000,
+            'upload_format': 'csv'
+        })))
+
+        create_data_set_patch.assert_any_call(match_equality(has_entries({
+            'data_group': 'apply-uk-visa',
+            'data_type': 'transactions-by-channel',
+            'max_age_expected': 1300000,
+            'upload_format': 'csv'
+        })))
 
         add_module_patch.assert_called_with(
             'apply-uk-visa', match_equality(has_entries(
@@ -744,7 +758,3 @@ class UploadPageTestCase(FlaskAppTestCase):
         assert_that(
             self.get_from_session('upload_data')['payload'],
             equal_to(['Message 1', 'Message 2']))
-
-    @patch('performanceplatform.client.admin.AdminAPI.get_data_set')
-    def test_data_added_to_backdrop(self, get_data_set_patch):
-        pass

--- a/tests/application/controllers/test_user_satisfaction.py
+++ b/tests/application/controllers/test_user_satisfaction.py
@@ -164,9 +164,10 @@ class AddUserSatisfactionTestCase(FlaskAppTestCase):
             'business_model': 'Department budget',
             'published': False,
             'status': 'unpublished',
-            'modules': [{
-                'data_type': 'user-satisfaction-score'
-            }]
+            'modules': [
+                {'data_type': 'user-satisfaction-score'},
+                {'slug': 'slug'}
+            ]
         }
 
         response = self.client.get(


### PR DESCRIPTION
When creating datasets through the admin app, we need to ensure that
autoids is populated correctly. This means that subsequent updates to
the data will overwrite previous values instead of creating duplicate
datapoints.