### PR TITLE
Keep user on Dashboard Hub page after updating

### DIFF
--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -45,7 +45,8 @@ def dashboard_hub(admin_client, uuid):
         data = form.data
         data["slug"] = dashboard_dict["slug"]
         admin_client.update_dashboard(uuid, data)
-        return redirect(url_for('dashboard_list'))
+        flash('Your dashboard has been updated', 'success')
+        return redirect(url_for('dashboard_hub', uuid=uuid))
     if form.errors:
         flash(to_error_list(form.errors), 'danger')
 

--- a/tests/application/controllers/test_dashboards.py
+++ b/tests/application/controllers/test_dashboards.py
@@ -135,11 +135,16 @@ class DashboardHubPageTestCase(FlaskAppTestCase):
     def test_dashboard_is_updated(
             self, mock_update_dashboard, mock_get_dashboard):
         data = self.params()
-        self.client.post('/dashboards/dashboard-uuid', data=data)
+        response = self.client.post('/dashboards/dashboard-uuid', data=data)
         post_json = mock_update_dashboard.call_args[0][1]
         assert_that(
             mock_update_dashboard.call_args[0][0], equal_to('dashboard-uuid'))
         assert_that(post_json, has_entries(data))
+        assert_that(response.status, equal_to('302 FOUND'))
+        assert_that(response.headers['Location'],
+                    ends_with('/dashboards/dashboard-uuid'))
+        self.assert_flashes(
+            'Your dashboard has been updated', 'success')
 
     @patch("application.controllers.dashboards.render_template")
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard")


### PR DESCRIPTION
When a user updates a dashboard's title or description on the dashboard hub page, they now remain on the hub page and will be shown a flash message to confirm the update was successful.

See story: https://www.pivotaltracker.com/story/show/97818448

