### PR TITLE
Fix broken link to cost per transaction

### DIFF
--- a/application/templates/builder/dashboard-hub.html
+++ b/application/templates/builder/dashboard-hub.html
@@ -69,7 +69,7 @@
              <li>the quarterly cost of running your service</li>
            </ul>
 
-           <p><a href="">Find out more about cost per transaction</a></p>
+           <p><a href="https://www.gov.uk/service-manual/measurement/cost-per-transaction">Find out more about cost per transaction</a></p>
            <p><a href="{{ url_for('upload_cost_per_transaction', uuid=uuid) }}" class="btn btn-info">Add cost per transaction</a></p>
          </div>
          {% endif %}


### PR DESCRIPTION
Fix the link to the service manual cost per transaction info.

Pivotal: https://www.pivotaltracker.com/story/show/97818246