### PR TITLE
Switch to container based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ notifications:
   email: false
 services:
   - redis-server
+cache: pip
+sudo: false


### PR DESCRIPTION
Travis support a container based infrastructure for running jobs -

http://docs.travis-ci.com/user/workers/container-based-infrastructure/

This should make builds start faster, and enable us to cache the pip
downloads between jobs, which should speed up builds.