### PR TITLE
Add update and continue button

### DIFF
--- a/application/controllers/admin/dashboards.py
+++ b/application/controllers/admin/dashboards.py
@@ -259,7 +259,10 @@ def dashboard_update(admin_client, module_types, form, uuid):
                   cgi.escape(form.title.data)
               ), 'success')
         del session['pending_dashboard']
-        return redirect(url_for('dashboard_list'))
+        if 'save_and_continue' in request.form:
+          return redirect(url_for('dashboard_form', uuid=uuid))
+        else:
+          return redirect(url_for('dashboard_list'))
     except (requests.HTTPError, ValueError, InvalidFormFieldError) as e:
         flash(format_error('updating', form, e), 'danger')
         return redirect(url_for('dashboard_form', uuid=uuid))
@@ -274,10 +277,13 @@ def dashboard_create(admin_client, module_types, form):
         if not form.validate():
             raise InvalidFormFieldError()
         dict_for_post = build_dict_for_post(form, module_types)
-        admin_client.create_dashboard(dict_for_post)
+        dashboard = admin_client.create_dashboard(dict_for_post)
         flash('Created the {} dashboard'.format(form.slug.data), 'success')
         del session['pending_dashboard']
-        return redirect(url_for('dashboard_list'))
+        if 'save_and_continue' in request.form:
+          return redirect(url_for('dashboard_form', uuid=dashboard['id']))
+        else:
+          return redirect(url_for('dashboard_list'))
     except (requests.HTTPError, ValueError, InvalidFormFieldError) as e:
         flash(format_error('creating', form, e), 'danger')
         return redirect(url_for('dashboard_form'))

--- a/application/controllers/admin/dashboards.py
+++ b/application/controllers/admin/dashboards.py
@@ -260,9 +260,9 @@ def dashboard_update(admin_client, module_types, form, uuid):
               ), 'success')
         del session['pending_dashboard']
         if 'save_and_continue' in request.form:
-          return redirect(url_for('dashboard_form', uuid=uuid))
+            return redirect(url_for('dashboard_form', uuid=uuid))
         else:
-          return redirect(url_for('dashboard_list'))
+            return redirect(url_for('dashboard_list'))
     except (requests.HTTPError, ValueError, InvalidFormFieldError) as e:
         flash(format_error('updating', form, e), 'danger')
         return redirect(url_for('dashboard_form', uuid=uuid))
@@ -281,9 +281,9 @@ def dashboard_create(admin_client, module_types, form):
         flash('Created the {} dashboard'.format(form.slug.data), 'success')
         del session['pending_dashboard']
         if 'save_and_continue' in request.form:
-          return redirect(url_for('dashboard_form', uuid=dashboard['id']))
+            return redirect(url_for('dashboard_form', uuid=dashboard['id']))
         else:
-          return redirect(url_for('dashboard_list'))
+            return redirect(url_for('dashboard_list'))
     except (requests.HTTPError, ValueError, InvalidFormFieldError) as e:
         flash(format_error('creating', form, e), 'danger')
         return redirect(url_for('dashboard_form'))

--- a/application/templates/admin/dashboards/create.html
+++ b/application/templates/admin/dashboards/create.html
@@ -35,11 +35,20 @@
         <p>
           <input type="submit" class="btn btn-default" value="Clone a module" name="clone_module">
         </p>
-        <p>
         {% if uuid %}
-        <input type="submit" class="btn btn-success" value="Update dashboard" name="create">
+         <p>
+            <input type="submit" class="btn btn-success" value="Update and continue" name="save_and_continue">
+          </p>
+        <p>
+          <input type="submit" class="btn btn-success" value="Update and return" name="save_and_return">
+        </p>
         {% else %}
-        <input type="submit" class="btn btn-success" value="Save new dashboard" name="create">
+        <p>
+          <input type="submit" class="btn btn-success" value="Create and continue" name="save_and_continue">
+        </p>
+        <p>
+         <input type="submit" class="btn btn-success" value="Create and return" name="save_and_return">
+        </p>
         {% endif %}
         </p>
         <p>

--- a/tests/application/controllers/admin/test_dashboards.py
+++ b/tests/application/controllers/admin/test_dashboards.py
@@ -725,6 +725,35 @@ class DashboardTestCase(FlaskAppTestCase):
         self.assert_flashes(expected_flash, expected_category='success')
 
     @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
+    def test_save_and_continue_button_for_update(self,
+                                         update_mock,
+                                         mock_list_organisations,
+                                         mock_list_data_sets,
+                                         mock_list_module_types):
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'admin']
+            }
+
+        data = valid_dashboard_data({
+            'save_and_continue':'',
+        })
+
+        resp = self.client.post(
+            '/admin/dashboards/uuid', data=data)
+
+        assert_that(resp.status_code, equal_to(302))
+        assert_that(
+            resp.headers['Location'],
+            ends_with('/admin/dashboards/uuid'))
+        expected_flash = 'Updated the <a href="http://spotlight.development' +\
+            '.performance.service.gov.uk/performance/valid-slug">' + \
+            'My valid title</a> dashboard'
+        self.assert_flashes(expected_flash, expected_category='success')
+
+
+    @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
     def test_updating_flash_escapes_title_html(self,
                                                update_mock,
                                                mock_list_organisations,

--- a/tests/application/controllers/admin/test_dashboards.py
+++ b/tests/application/controllers/admin/test_dashboards.py
@@ -726,10 +726,10 @@ class DashboardTestCase(FlaskAppTestCase):
 
     @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
     def test_save_and_continue_button_for_update(self,
-                                         update_mock,
-                                         mock_list_organisations,
-                                         mock_list_data_sets,
-                                         mock_list_module_types):
+                                                 update_mock,
+                                                 mock_list_organisations,
+                                                 mock_list_data_sets,
+                                                 mock_list_module_types):
         with self.client.session_transaction() as session:
             session['oauth_token'] = {'access_token': 'token'}
             session['oauth_user'] = {
@@ -752,6 +752,30 @@ class DashboardTestCase(FlaskAppTestCase):
             'My valid title</a> dashboard'
         self.assert_flashes(expected_flash, expected_category='success')
 
+    @patch("performanceplatform.client.admin.AdminAPI.create_dashboard")
+    def test_save_and_continue_button_for_create(self,
+                                                 create_dashboard,
+                                                 mock_list_organisations,
+                                                 mock_list_data_sets,
+                                                 mock_list_module_types):
+        with self.client.session_transaction() as session:
+            session['oauth_token'] = {'access_token': 'token'}
+            session['oauth_user'] = {
+                'permissions': ['signin', 'admin']
+            }
+
+        data = valid_dashboard_data({
+            'save_and_continue': '',
+        })
+        dashboard_id = 1234
+        create_dashboard.return_value = {'id': dashboard_id}
+        resp = self.client.post(
+            '/admin/dashboards', data=data)
+
+        assert_that(resp.status_code, equal_to(302))
+        assert_that(
+            resp.headers['Location'],
+            ends_with('/admin/dashboards/{}'.format(dashboard_id)))
 
     @patch("performanceplatform.client.admin.AdminAPI.update_dashboard")
     def test_updating_flash_escapes_title_html(self,


### PR DESCRIPTION
This PR adds an (update | create) and continue button to the BIG EDIT action so that users can save their progress as they work rather than being punted back to the index page on save.

Pivotal: https://www.pivotaltracker.com/story/show/90792104

![screen shot 2015-07-07 at 17 59 34](https://cloud.githubusercontent.com/assets/68009/8551984/fd4a4478-24d1-11e5-9787-f4e80740ae55.png)

**Notes for the reviewer**
  1. I had to change the words on the buttons a bit so that it was clear
what each button was doing, I'm not sure I got it right so if you think
it could be improved please let me know.
  2. I found writing the test for this a bit confusing, I took the test for
the regular update path (test_updating_existing_dashboard) and 
modified it, removing some of the assertions which are already
covered so (i think) this only tests the thing I want it to; that if the 
`save_and_continue` param is present then the action redirects
back to the edit page. Not sure if this was the right thing to do or not.
  3. This is the first python I've written for about 10 years, and
the first flask app I've ever committed to. In those 10 years my brain
has been very corrupted by ruby so if any of this isn't very 
pythonesque, please tell me.