### PR TITLE
Display error page if datasets list fail to load.

### DIFF
--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -115,6 +115,7 @@ def dashboard_list(admin_client):
                            dashboards=dashboard_response,
                            **template_context)
 
+
 @app.route('{0}/<uuid>'.format(DASHBOARD_DELETE), methods=['GET', 'DELETE'])
 @requires_authentication
 @requires_feature('big-edit')

--- a/application/controllers/upload.py
+++ b/application/controllers/upload.py
@@ -10,6 +10,19 @@ from application.helpers import(
     base_template_context,
     group_by_group)
 from performanceplatform.client.data_set import DataSet
+import traceback
+
+
+@app.errorhandler(StandardError)
+def internal_error(err):
+    template_context = base_template_context()
+    template_context.update({
+        'user': session['oauth_user'],
+    })
+    print(traceback.format_exc())
+    return render_template('error.html',
+                           error="There has been an error",
+                           **template_context), 500
 
 
 @app.route('/upload-data', methods=['GET'])
@@ -23,6 +36,7 @@ def upload_list_data_sets(admin_client):
             return redirect(url_for('oauth_sign_out'))
         else:
             raise
+
     template_context.update({
         'user': session['oauth_user'],
         'data_sets': data_sets

--- a/application/templates/error.html
+++ b/application/templates/error.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Performance Platform admin{% endblock %}
+
+{% block body %}
+
+<div class="row">
+  <div class="col-xs-8">
+    <h2>Performance Platform admin</h2>
+    <p>
+      {{ error }}
+    </p>
+    <p>
+      Please try again later.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/application/controllers/test_dashboards.py
+++ b/tests/application/controllers/test_dashboards.py
@@ -168,7 +168,7 @@ class DashboardHubPageTestCase(FlaskAppTestCase):
             environment=match_equality(not_none()),
             user=match_equality(not_none()),
         )
-        #mock_render_template.assert_called_once_with('abc')
+        # mock_render_template.assert_called_once_with('abc')
 
     @patch("performanceplatform.client.admin.AdminAPI.get_dashboard",
            return_value=dashboard_data())

--- a/tests/application/controllers/test_upload.py
+++ b/tests/application/controllers/test_upload.py
@@ -333,6 +333,24 @@ class UploadTestCase(FlaskAppTestCase):
 
     @signed_in()
     @patch('performanceplatform.client.admin.AdminAPI.list_data_sets')
+    def test_data_sets_renders_error_page_when_500_on_data_set_list(
+            self,
+            mock_data_set_list,
+            client):
+
+        http_error = requests.exceptions.HTTPError()
+        bad_response = Mock()
+        bad_response.status_code = 500
+        bad_response.content = '{"message": "Test Error"}'
+        http_error.response = bad_response
+
+        mock_data_set_list.side_effect = http_error
+        response = client.get("/upload-data")
+
+        self.assert_template_used('error.html')
+
+    @signed_in()
+    @patch('performanceplatform.client.admin.AdminAPI.list_data_sets')
     def test_data_sets_renders_a_data_set_list_and_okay_message_on_success(
             self,
             mock_data_set_list,


### PR DESCRIPTION
When trying to access the upload data page in the self serve app,
if an http error is returned from stagecraft, then this exception
is just thrown back to the user, e.g. a 500 Internal Server Error
is returned and not a nice validation message.

The only exception to this are 401s. They redirect the user to a
sign out page.

Changed this behaviour to display an error page if any http error
except a 401 is returned from stagecraft.

https://www.pivotaltracker.com/story/show/97501524