### PR TITLE
Requests by humans should not be retried.

### DIFF
--- a/application/controllers/upload.py
+++ b/application/controllers/upload.py
@@ -80,7 +80,8 @@ def upload_spreadsheet(data_set, file_data):
                 url = '{0}/data/{1}/{2}'.format(app.config['BACKDROP_HOST'],
                                                 data_set['data_group'],
                                                 data_set['data_type'])
-                data_set = DataSet(url, data_set['bearer_token'])
+                data_set = DataSet(url, data_set['bearer_token'],
+                                   retry_on_error=False)
                 try:
                     data_set.post(spreadsheet.as_json())
                 except HTTPError as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ graphviz==0.4.2
 gunicorn==18.0
 logstash_formatter==0.5.7
 ndg-httpsclient==0.3.2
-performanceplatform-client==0.10.2
+performanceplatform-client==0.10.3
 pyasn1==0.1.7
 pyOpenSSL==0.14
 pytz==2014.4


### PR DESCRIPTION
Take advantage of the new property in Performance Platform Client
that allows youto choose whether requests should be exponentially
backed off.

The default behaviour is to retry a request 5 times on a 5xx failure.
All requests made through the Admin App involve human interaction
and do no need to be retried.

Should be merged after:
https://github.com/alphagov/performanceplatform-client.py/pull/63

https://www.pivotaltracker.com/story/show/97501524