### PR TITLE
Update for govuk dev vm

### DIFF
--- a/application/config/development.py
+++ b/application/config/development.py
@@ -2,8 +2,8 @@ COOKIE_SECRET_KEY = 'placeholder_cookie_secret_key'
 
 ADMIN_HOST = 'https://admin-beta.development.performance.service.gov.uk'
 
-BACKDROP_HOST = 'http://www.development.performance.service.gov.uk'
-STAGECRAFT_HOST = 'http://stagecraft.development.performance.service.gov.uk'
+BACKDROP_HOST = 'http://localhost:3039'
+STAGECRAFT_HOST = 'http://localhost:3204'
 
 GOVUK_SITE_URL = 'http://spotlight.development.performance.service.gov.uk'
 SIGNON_OAUTH_ID = 'oauth_id'

--- a/start-app.sh
+++ b/start-app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PORT=${1:-3070}
+PORT=${1:-3104}
 VENV_DIR=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))-$PORT-$2
 
 if [ -z "$VIRTUAL_ENV" ]; then


### PR DESCRIPTION
Use backdrop and stagecraft directly, rather than through nginx, and
match the default port in start app.sh to the port specified in the
development repo procfile