### PR TITLE
Publish dashboard

### DIFF
--- a/application/config/development.py
+++ b/application/config/development.py
@@ -1,9 +1,9 @@
 COOKIE_SECRET_KEY = 'placeholder_cookie_secret_key'
 
-ADMIN_HOST = 'https://admin-beta.development.performance.service.gov.uk'
+ADMIN_HOST = 'http://performanceplatform-admin.dev.gov.uk/'
 
-BACKDROP_HOST = 'http://www.development.performance.service.gov.uk'
-STAGECRAFT_HOST = 'http://stagecraft.development.performance.service.gov.uk'
+BACKDROP_HOST = 'http://localhost:3039'
+STAGECRAFT_HOST = 'http://stagecraft.dev.gov.uk'
 
 GOVUK_SITE_URL = 'http://spotlight.development.performance.service.gov.uk'
 SIGNON_OAUTH_ID = 'oauth_id'

--- a/application/controllers/dashboards.py
+++ b/application/controllers/dashboards.py
@@ -132,3 +132,22 @@ def dashboard_delete(admin_client, uuid):
     else:
         flash('Cannot delete published dashboard', 'info')
         return redirect(url_for('dashboard_list'))
+
+
+@app.route('{0}/<uuid>/publish'.format(DASHBOARD_ROUTE),
+           methods=['GET', 'POST'])
+@requires_authentication
+@requires_feature('big-edit')
+def publish_dashboard(admin_client, uuid):
+    dashboard_dict = admin_client.get_dashboard(uuid)
+    if dashboard_dict['status'] == 'unpublished':
+        admin_client.update_dashboard(
+            uuid, {
+                'status': 'published',
+                'slug': dashboard_dict["slug"],
+                'title': dashboard_dict["title"]
+            })
+        flash('Your dashboard has been published', 'success')
+    else:
+        flash('Dashboard already published', 'info')
+    return redirect(url_for('dashboard_list'))

--- a/application/templates/dashboards/index.html
+++ b/application/templates/dashboards/index.html
@@ -35,6 +35,7 @@
                   {% endif %}
                   <li><a class='btn btn-primary' href="{{ dashboard['public-url'] }}" target="_blank">Preview</a></li>
                   {% if dashboard.status == "unpublished" and user_has_feature('big-edit', user)%}
+                    <li><a class='btn btn-warning' href="{{ url_for('publish_dashboard', uuid=dashboard.id) }}">Publish</a></li>
                     <li><a class='btn btn-warning' href="{{ url_for('dashboard_delete', uuid=dashboard.id) }}">Delete dashboard</a></li>
                   {% endif %}
               </ul>


### PR DESCRIPTION
Publishing a dashboard is usually dev task. This can now be done by the
onboarding team or anyone with 'big-edit' permissions.

Publish uses the existing update_dashboard method in the admin client,
so no changes to performanceplatform-client or stagecraft are required.

Pivotal: https://www.pivotaltracker.com/story/show/90782838

There is also a fix to get the self-serve app working on the govuk dev vm.