### PR TITLE
Display content of lists and menus in alphabetical order

### DIFF
--- a/application/forms.py
+++ b/application/forms.py
@@ -83,6 +83,7 @@ class ModuleTypes():
             for module in self.types
             if module['name'] != 'section'
         ]
+        choices.sort(key=lambda tup: tup[1])
         return choices
 
 
@@ -169,22 +170,22 @@ class DashboardCreationForm(Form):
             m.data_type.choices = data_sources.type_choices()
 
     dashboard_type = SelectField('Dashboard type', choices=[
-        ('transaction', 'Transaction'),
+        ('agency', 'Agency'),
+        ('content', 'Content'),
+        ('department', 'Department'),
         ('high-volume-transaction', 'High volume transaction'),
         ('service-group', 'Service group'),
-        ('agency', 'Agency'),
-        ('department', 'Department'),
-        ('content', 'Content'),
+        ('transaction', 'Transaction'),
         ('other', 'Other'),
     ])
     strapline = SelectField('Strapline', choices=[
-        ('Dashboard', 'Dashboard'),
-        ('Service dashboard', 'Service dashboard'),
         ('Content dashboard', 'Content dashboard'),
+        ('Dashboard', 'Dashboard'),
         ('Performance', 'Performance'),
         ('Policy dashboard', 'Policy dashboard'),
         ('Public sector purchasing dashboard',
          'Public sector purchasing dashboard'),
+        ('Service dashboard', 'Service dashboard'),
     ])
     slug = TextField('Dashboard URL')
     title = TextField('Dashboard title')

--- a/application/templates/data_sets.html
+++ b/application/templates/data_sets.html
@@ -37,11 +37,11 @@
     <hr>
     {% if data_sets %}
       <ul class="list-unstyled data-group-list">
-        {% for group_name in data_sets %}
+        {% for group_name in data_sets|sort %}
         <li data-name={{group_name}}>
           <h3 class="data-group-name">{{ group_name }}</h3>
           <ul class="list-unstyled data-set-list">
-            {% for data_set in data_sets[group_name] %}
+            {% for data_set in data_sets[group_name]|sort(attribute='data_type') %}
             <li>
               {% include "upload/form.html" %}
               {% if upload_data and upload_data.data_group == data_set.data_group and upload_data.data_type == data_set.data_type %}


### PR DESCRIPTION
Items in dropdown menus and in unstructured lists (eg data-group-lists on upload data screen) to be arranged alphabetically.

On the upload data page, first, display data groups in alphabetical order, then display the data sets associated with the data group in data type order.

In Big Edit, alphabetise lists for 
1. Strapline, 
2. Dashboard Type
3. Module Type

Pivotal: https://www.pivotaltracker.com/story/show/95028568