### PR TITLE
Filter data source type by group selection on update dashboard form

### DIFF
--- a/application/static/javascripts/edit_dashboard.js
+++ b/application/static/javascripts/edit_dashboard.js
@@ -1,5 +1,19 @@
 (function () {
 
+  function filterDataTypeBySelectedGroup() {
+    $('.data-group').each(function () {
+      var data_group = $(this);
+      var module_index = data_group.attr('id').replace('-data_group', '');
+      var data_type = $('#' + module_index + '-data_type');
+      data_group.on('change', function () {
+        var group = data_group.val();
+        data_type.children().show();
+        data_type.children('[label!=' + group + ']').hide();
+        data_type.val(data_type.find('[label=' + group  + '] option')[0].value);
+      });
+    });
+  }
+
   function setQueryParamsFromModuleType() {
     $('.js-module-type-selector').on('change', function () {
       var type = $(this).find('[value="' + $(this).val() + '"]').text(),
@@ -41,6 +55,8 @@
     });
     return modules.join(',');
   }
+
+  filterDataTypeBySelectedGroup();
 
   setQueryParamsFromModuleType();
 

--- a/application/templates/admin/dashboards/create.html
+++ b/application/templates/admin/dashboards/create.html
@@ -219,11 +219,11 @@
               <label class="col-sm-2 control-label">Data source</label>
               <div class="col-sm-5">
                 {{ module.data_group.label(class='sr-only') }}
-                {{ module.data_group(class='form-control', placeholder='carers-allowance') }}
+                {{ module.data_group(class='form-control data-group', placeholder='carers-allowance') }}
               </div>
               <div class="col-sm-5">
                 {{ module.data_type.label(class='sr-only') }}
-                {{ module.data_type(class='form-control', placeholder='realtime') }}
+                {{ module.data_type(class='form-control data-type', placeholder='realtime') }}
               </div>
             </div>
           {% endif %}


### PR DESCRIPTION
## What

* Added javascript to filter options in Data source type dropdown by the selected Data source group value, to reduce the number of options displayed and avoid users having to scroll through a huge list of irrelevant options.
* Added class names to the form fields involved, to provide a hook for the javascript

## How to review

1. Edit a dashboard with the BIG EDIT button
2. Find a module with Data source fields
3. Select a group from the first dropdown
4. See the options in the second dropdown are restricted to those associated with the selected group