### PR TITLE
Make module description and info fields into textareas

### DIFF
--- a/application/forms.py
+++ b/application/forms.py
@@ -135,8 +135,8 @@ class ModuleForm(Form):
 
     slug = TextField('Module URL')
     title = TextField('Title')
-    description = TextField('Description')
-    info = TextField('Info')
+    description = TextAreaField('Description')
+    info = TextAreaField('Info')
 
     query_parameters = JSONTextAreaField('Query parameters', default='{}')
     options = JSONTextAreaField('Visualisation settings', default='{}')


### PR DESCRIPTION
## What

* Changed description and info textfields in module form into textareafields, so that they render as multi-line fields

## How to review

1. Edit a dashboard using the BIG EDIT button
2. Find a module with info and description fields
3. See that the fields are now multiline text areas

It was also requested that the maximum input length on the description field be updated to 400 characters (from 200), but this change needs to be made in the stagecraft API.