### PR TITLE
Change default text created when module type is selected

### DIFF
--- a/application/static/json/completion_rate.json
+++ b/application/static/json/completion_rate.json
@@ -1,11 +1,11 @@
 {
   "query": {
-    "duration": 52,
     "collect": [
       "count:sum"
     ],
+    "duration": 52,
     "group_by": [
-      "channel"
+      "stage"
     ],
     "period": "week"
   },
@@ -23,14 +23,17 @@
             {
                 "format": "percent", 
                 "key": "completion", 
-                "label": "Digital take-up"
+                "label": "Completion rate"
             }
         ]
     }, 
     "axis-period": "month", 
-    "denominator-matcher": ".+", 
-    "matching-attribute": "channel", 
-    "numerator-matcher": "(Digital)", 
+    "date-picker": {
+        "start-date": "206-08-29"
+    },
+    "denominator-matcher": "start", 
+    "matching-attribute": "stage", 
+    "numerator-matcher": "complete", 
     "value-attribute": "count:sum"
   }
 }

--- a/application/static/json/grouped_timeseries.json
+++ b/application/static/json/grouped_timeseries.json
@@ -1,13 +1,15 @@
 {
   "query": {
-    "duration": 52,
     "collect": [
       "count:sum"
     ],
+    "duration": 52,
+    "filter_by": [],
     "group_by": [
       "channel"
     ],
-    "period": "week"
+    "period": "week",
+    "sort_by": "_timestamp:ascending"
   },
   "visualisation" : {
     "axes": {
@@ -24,27 +26,31 @@
         }, 
         "y": [
             {
-                "format": "percent", 
-                "groupId": "desktop", 
-                "label": "Desktop"
+                "format": "integer", 
+                "groupId": "digital", 
+                "label": "Digital"
             }, 
             {
-                "format": "percent", 
-                "groupId": "mobile", 
-                "label": "Mobile"
+                "format": "integer", 
+                "groupId": "phone", 
+                "label": "Phone"
             }, 
             {
-                "format": "percent", 
-                "groupId": "tablet", 
-                "label": "Tablet"
+                "format": "integer", 
+                "groupId": "paper", 
+                "label": "Paper"
             }
         ]
     }, 
-    "axis-period": "month", 
-    "category": "deviceCategory", 
-    "one-hundred-percent": true, 
+    "axis-period": "week", 
+    "date-picker": {
+        "start-date": "2016-01-01"
+    },
+    "format": "number",
+    "one-hundred-percent": false, 
     "show-line-labels": true, 
-    "use_stack": false, 
-    "value-attribute": "visitors:sum"
+    "show-total-label": true,
+    "use_stack": true, 
+    "value-attribute": "count:sum"
   }
 }

--- a/application/static/json/single_timeseries.json
+++ b/application/static/json/single_timeseries.json
@@ -1,16 +1,6 @@
 {  
   "query": {
-    "duration": 52,
-    "collect": [
-      "avgSessionDuration:sum"
-    ],
-    "group_by": [
-      "stage"
-    ],
-    "period": "week",
-    "filter_by": [
-      "stage:thank-you"
-    ]
+    "sort_by": "_timestamp:ascending"
   },
   "visualisation" : {
     "axes": {
@@ -24,15 +14,24 @@
         }, 
         "y": [
             {
-                "format": "integer", 
-                "label": "Completed applications"
+                "format": {
+                    "pence": true,
+                    "type": "currency"
+                },
+                "label": "Average value"
             }
         ]
     }, 
-    "category": "stage", 
-    "show-line-labels": true, 
-    "show-total-lines": true, 
-    "use_stack": false, 
-    "value-attribute": "count:sum"
+    "axis-period": "month",
+    "date-picker": {
+        "start-date": "2016-08-29"
+    },
+    "format-options": {
+        "dps": 5,
+        "magnitude": true,
+        "sigfigs": 5,
+        "type": "number"
+    },
+    "value-attribute": "rate"
   }
 }

--- a/application/static/json/user_satisfaction_graph.json
+++ b/application/static/json/user_satisfaction_graph.json
@@ -1,49 +1,12 @@
 {
-  "query": {},
+  "query": {
+      "duration": 52,
+      "period": "week"
+  },
   "visualisation": {
-    "axes": {
-        "x": {
-            "format": "date", 
-            "key": "_start_at", 
-            "label": "Date"
-        }, 
-        "y": [
-            {
-                "format": "percent", 
-                "key": "score", 
-                "label": "User satisfaction"
-            }, 
-            {
-                "format": "integer", 
-                "key": "rating_1", 
-                "label": "Very dissatisfied"
-            }, 
-            {
-                "format": "integer", 
-                "key": "rating_2", 
-                "label": "Dissatisfied"
-            }, 
-            {
-                "format": "integer", 
-                "key": "rating_3", 
-                "label": "Neither satisfied or dissatisfied"
-            }, 
-            {
-                "format": "integer", 
-                "key": "rating_4", 
-                "label": "Satisfied"
-            }, 
-            {
-                "format": "integer", 
-                "key": "rating_5", 
-                "label": "Very satisfied"
-            }
-        ]
-    }, 
-    "axis-period": "month", 
-    "migrated": true, 
-    "total-attribute": "num_responses", 
-    "trim": false, 
-    "value-attribute": "score"
+    "date-picker": {
+        "start-date": "2016-01-01"
+    },
+    "value-attribute": "rating"
   }
 }


### PR DESCRIPTION
## What

* Updated JSON files for group_timeseries, single_timeseries, completion_rate and user_satisfaction_graph to change default query parameters and visualisation settings

## How to review

1. Edit a dashboard with the BIG EDIT button
2. Change a module type to one of the 4 types listed above
3. See the Query parameters and Visualisation settings match the JSON shown in the [Platform Work Priorities spreadsheet](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1L2C-27yClmc9ceTIUth098N886LP5vxY-K62A3ukQNg/edit?usp=sharing)